### PR TITLE
fix:(perf) deduplicate global key listeners and stabilize handler

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,7 +2,7 @@ import React, { use, useCallback, useEffect } from 'react';
 import './App.css';
 import Header from './components/Header/Header';
 import Main from './components/Main/Main';
-import useKeyPress from './hooks/keyboardEvents/useKeyPress';
+import { useGlobalKeyPress } from './hooks/keyboardEvents/useKeyPress';
 import useTheme from './hooks/useTheme';
 import AchievementsStack from './components/AchievementsStack/AchievementsStack';
 import Tab from './components/Tab/Tab';
@@ -75,7 +75,7 @@ const App: React.FC<AppProp> = ({ onLoad }) => {
 
   use(twemojiPromise);
 
-  useKeyPress();
+  useGlobalKeyPress();
 
   useEffect(() => {
     onLoad?.();

--- a/front/src/hooks/keyboardEvents/useKeyPress.ts
+++ b/front/src/hooks/keyboardEvents/useKeyPress.ts
@@ -1,33 +1,65 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import useShortcuts from './useShortcuts';
 import useGameLogic from './useGameLogic';
 import useGameStore from '../../stores/useGameStore';
 import useUIStore from '../../stores/useUIStore';
 import useChatStore from '../../stores/useChatStore';
 
+const isGameKey = (event: KeyboardEvent) => ['Enter', 'Backspace'].includes(event.key) || /^[a-z]$/.test(event.key);
+
 const useKeyPress = () => {
-  const { gameFinished } = useGameStore();
-  const { isAnyInterfaceOpen, showChat } = useUIStore();
-  const { focusInput } = useChatStore();
+  const gameFinished = useGameStore((s) => s.gameFinished);
+  const isAnyInterfaceOpen = useUIStore((s) => s.isAnyInterfaceOpen);
+  const showChat = useUIStore((s) => s.showChat);
+  const focusInput = useChatStore((s) => s.focusInput);
 
   const shortcutsState = useShortcuts();
   const gameLogicState = useGameLogic();
 
-  const isGameKey = (event: KeyboardEvent) => ['Enter', 'Backspace'].includes(event.key) || /^[a-z]$/.test(event.key);
+  const handlersRef = useRef({
+    showChat,
+    isAnyInterfaceOpen,
+    focusInput,
+    gameFinished,
+    shortcutsKeyDown: shortcutsState.handleKeyDown,
+    shortcutsKeyUp: shortcutsState.handleKeyUp,
+    gameKeyDown: gameLogicState.handleKeyDown,
+  });
 
-  const handleKeyPress = (event: KeyboardEvent, state: 'up' | 'down') => {
+  handlersRef.current = {
+    showChat,
+    isAnyInterfaceOpen,
+    focusInput,
+    gameFinished,
+    shortcutsKeyDown: shortcutsState.handleKeyDown,
+    shortcutsKeyUp: shortcutsState.handleKeyUp,
+    gameKeyDown: gameLogicState.handleKeyDown,
+  };
+
+  const handleKeyPress = useCallback((event: KeyboardEvent, state: 'up' | 'down') => {
+    const h = handlersRef.current;
     if (state === 'down') {
-      if (showChat && isGameKey(event)) {
-        focusInput();
-      } else if (!isGameKey(event) || gameFinished() || event.altKey) {
-        shortcutsState.handleKeyDown(event);
-      } else if (!isAnyInterfaceOpen() && !gameFinished()) {
-        gameLogicState.handleKeyDown(event);
+      if (h.showChat && isGameKey(event)) {
+        h.focusInput();
+      } else if (!isGameKey(event) || h.gameFinished() || event.altKey) {
+        h.shortcutsKeyDown(event);
+      } else if (!h.isAnyInterfaceOpen() && !h.gameFinished()) {
+        h.gameKeyDown(event);
       }
     } else {
-      shortcutsState.handleKeyUp(event);
+      h.shortcutsKeyUp(event);
     }
+  }, []);
+
+  return {
+    ...shortcutsState,
+    ...gameLogicState,
+    handleKeyPress,
   };
+};
+
+export const useGlobalKeyPress = () => {
+  const { handleKeyPress } = useKeyPress();
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => handleKeyPress(e, 'down');
@@ -40,21 +72,7 @@ const useKeyPress = () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [
-    showChat,
-    isAnyInterfaceOpen,
-    focusInput,
-    gameFinished,
-    shortcutsState.handleKeyDown,
-    shortcutsState.handleKeyUp,
-    gameLogicState.handleKeyDown,
-  ]);
-
-  return {
-    ...shortcutsState,
-    ...gameLogicState,
-    handleKeyPress,
-  };
+  }, [handleKeyPress]);
 };
 
 export default useKeyPress;


### PR DESCRIPTION
useKeyPress was called from both App and Keyboard, mounting the global keydown/keyup listeners twice and rebinding them on every render due to unstable deps; the listener mounting is now factored into a single useGlobalKeyPress hook called only from App, with handlers stabilized via a ref.