### PR TITLE
fix:(perf) replace whole-store destructures with selectors

### DIFF
--- a/front/src/components/AchievementsStack/AchievementsStack.tsx
+++ b/front/src/components/AchievementsStack/AchievementsStack.tsx
@@ -10,7 +10,8 @@ interface AchievementsStackProps {
 }
 
 const AchievementsStack: React.FC<AchievementsStackProps> = ({ lifeTime, transitionDuration }) => {
-  const { achievements, removeAchievement } = useGameStore();
+  const achievements = useGameStore((s) => s.achievements);
+  const removeAchievement = useGameStore((s) => s.removeAchievement);
   const handleSlideOutEnd = (id: string) => {
     removeAchievement(id);
   };

--- a/front/src/components/Chat/Chat.tsx
+++ b/front/src/components/Chat/Chat.tsx
@@ -37,8 +37,9 @@ interface ChatProps {
 
 function Chat({ chatButtonRef }: ChatProps): JSX.Element {
   const chatRef = useRef<HTMLDivElement>(null);
-  const { messages } = useChatStore();
-  const { showChat: display, setVisibility } = useUIStore();
+  const messages = useChatStore((s) => s.messages);
+  const display = useUIStore((s) => s.showChat);
+  const setVisibility = useUIStore((s) => s.setVisibility);
   const [isNearBottom, setIsNearBottom] = useState(true);
   const scrollToBottom = useChatStore((state) => state.scrollToBottom);
 

--- a/front/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/front/src/components/Chat/ChatInput/ChatInput.tsx
@@ -27,8 +27,12 @@ export function SimpleMessage({ message }: { message: Server.ChatMessage.SavedTy
 function ChatInput({ onSend, display }: ChatInputProps): JSX.Element {
   const keyboardRef = useRef<HTMLInputElement>(null);
   const [input, setInputValue] = useState<string>('');
-  const { sendMessage: sendWebSocketMessage } = useWebSocketStore();
-  const { answeringTo, setAnsweringTo, messages, focusInput, setFocusInput } = useChatStore();
+  const sendWebSocketMessage = useWebSocketStore((s) => s.sendMessage);
+  const answeringTo = useChatStore((s) => s.answeringTo);
+  const setAnsweringTo = useChatStore((s) => s.setAnsweringTo);
+  const messages = useChatStore((s) => s.messages);
+  const focusInput = useChatStore((s) => s.focusInput);
+  const setFocusInput = useChatStore((s) => s.setFocusInput);
   const { push: pushHistory, handleKeyDown: handleHistoryKeyDown, reset: resetHistory, inputRef: historyInputRef } = useChatInputHistory();
   const [cursorPos, setCursorPos] = useState(0);
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/front/src/components/Chat/MessagesBox/Message/Content/ScoreContent.tsx
+++ b/front/src/components/Chat/MessagesBox/Message/Content/ScoreContent.tsx
@@ -11,7 +11,7 @@ function ScoreContent({ message }: { message: Server.ChatMessage.Score }): JSX.E
   const tries = message.content.attempts;
   const answer = message.content.answer;
   const words = getValidatedWords(tries, answer);
-  const { gameFinished } = useGameStore();
+  const gameFinished = useGameStore((s) => s.gameFinished);
 
   return (
     <span>

--- a/front/src/components/Chat/MessagesBox/Message/Message.tsx
+++ b/front/src/components/Chat/MessagesBox/Message/Message.tsx
@@ -40,8 +40,9 @@ const MessageContent = ({ message }: { message: Server.ChatMessage.Type }): JSX.
 };
 
 function Message({ message }: { message: Server.ChatMessage.Type }): JSX.Element {
-  const { setAnsweringTo, focusInput } = useChatStore();
-  const { sendMessage } = useWebSocketStore();
+  const setAnsweringTo = useChatStore((s) => s.setAnsweringTo);
+  const focusInput = useChatStore((s) => s.focusInput);
+  const sendMessage = useWebSocketStore((s) => s.sendMessage);
   const username = useGameStore((state) => state.player.name);
   const myModeratorLevel = useGameStore((state) => state.player.moderatorLevel);
 

--- a/front/src/components/Chat/MessagesBox/Message/ReplyMessage/ReplyMessage.tsx
+++ b/front/src/components/Chat/MessagesBox/Message/ReplyMessage/ReplyMessage.tsx
@@ -9,7 +9,7 @@ interface ReplyMessageProps {
 }
 
 function ReplyMessage({ message }: ReplyMessageProps) {
-  const { messages } = useChatStore();
+  const messages = useChatStore((s) => s.messages);
 
   const messageFromId = (id: string): Server.ChatMessage.SavedType | undefined => {
     return messages.find((m) => isSavedChatMessage(m) && m.content.id === id);

--- a/front/src/components/CustomWord/CustomWord.tsx
+++ b/front/src/components/CustomWord/CustomWord.tsx
@@ -14,8 +14,9 @@ interface CustomWordProps {
 }
 
 function CustomWord({ customWordButtonRef }: CustomWordProps): JSX.Element {
-  const { addAchievement } = useGameStore();
-  const { setVisibility, showCustomWord: display } = useUIStore();
+  const addAchievement = useGameStore((s) => s.addAchievement);
+  const setVisibility = useUIStore((s) => s.setVisibility);
+  const display = useUIStore((s) => s.showCustomWord);
 
   const [customWord, setCustomWord] = useState<string>('');
   const customWordRef = useRef(null);

--- a/front/src/components/EndPage/EndPage.tsx
+++ b/front/src/components/EndPage/EndPage.tsx
@@ -17,8 +17,9 @@ interface EndPageProps {
 
 function EndPage({ endPageButtonRef }: EndPageProps): JSX.Element {
   const tries = useGameStore((state) => state.tries);
-  const { sendMessage } = useWebSocketStore();
-  const { showEndPage: display, setVisibility } = useUIStore();
+  const sendMessage = useWebSocketStore((s) => s.sendMessage);
+  const display = useUIStore((s) => s.showEndPage);
+  const setVisibility = useUIStore((s) => s.setVisibility);
 
   const endPageRef = useRef<HTMLDivElement | null>(null);
   const emojiScore = useMemo(() => {

--- a/front/src/components/Main/ExperienceBar/ExperienceBar.tsx
+++ b/front/src/components/Main/ExperienceBar/ExperienceBar.tsx
@@ -14,7 +14,7 @@ interface ExperienceBarProps {
 
 function ExperienceBar({ xp }: ExperienceBarProps): JSX.Element {
   const level = getLevel(xp);
-  const { hasLoaded } = useGameStore.getState();
+  const hasLoaded = useGameStore((s) => s.hasLoaded);
 
   const [realtimeLevel, setRealtimeLevel] = useState<number>(level);
   const integerPart = Math.floor(realtimeLevel);

--- a/front/src/components/Main/Game/Game.tsx
+++ b/front/src/components/Main/Game/Game.tsx
@@ -4,7 +4,9 @@ import Grid from './Grid/Grid';
 import useGameStore from '../../../stores/useGameStore';
 
 function Game(): JSX.Element {
-  const { solution, tries, letters } = useGameStore();
+  const solution = useGameStore((s) => s.solution);
+  const tries = useGameStore((s) => s.tries);
+  const letters = useGameStore((s) => s.letters);
   const shownSolution = solution ?? '      ';
 
   function getChestLabel(length: number): string {

--- a/front/src/components/Main/Keyboard/Keyboard.tsx
+++ b/front/src/components/Main/Keyboard/Keyboard.tsx
@@ -12,7 +12,7 @@ interface KeyboardProps {
 }
 
 const Keyboard = React.memo(function Keyboard({ layout }: KeyboardProps): JSX.Element {
-  const { tries } = useGameStore();
+  const tries = useGameStore((s) => s.tries);
   const [keys, setKeys] = useState(() => getKeyboardLayout(layout));
   const [keyboardClass, setKeyboardClass] = useState(() => getKeyboardClass(layout));
   const [pressedKey, setPressedKey] = useState<string | null>(null);

--- a/front/src/components/Main/Main.tsx
+++ b/front/src/components/Main/Main.tsx
@@ -29,7 +29,7 @@ function Main({
   chatButtonRef,
 }: MainProps): JSX.Element {
   const layout = useKeyboardLayout();
-  const { player } = useGameStore();
+  const player = useGameStore((s) => s.player);
 
   return (
     <main

--- a/front/src/components/Main/Tools/Tools.tsx
+++ b/front/src/components/Main/Tools/Tools.tsx
@@ -37,8 +37,9 @@ function Tools({
   chatButtonRef,
   customWordButtonRef,
 }: ToolsProps): JSX.Element {
-  const { playerList, gameFinished } = useGameStore();
-  const { toggle } = useUIStore();
+  const playerList = useGameStore((s) => s.playerList);
+  const gameFinished = useGameStore((s) => s.gameFinished);
+  const toggle = useUIStore((s) => s.toggle);
 
   const nbUsers = playerList.length;
 

--- a/front/src/components/Stats/Stats.tsx
+++ b/front/src/components/Stats/Stats.tsx
@@ -14,8 +14,9 @@ interface StatsProps {
 
 function Stats({ statsButtonRef }: StatsProps): JSX.Element {
   const statsRef = React.useRef<HTMLDivElement>(null);
-  const { scores } = useGameStore();
-  const { setVisibility, showStats: display } = useUIStore();
+  const scores = useGameStore((s) => s.scores);
+  const setVisibility = useUIStore((s) => s.setVisibility);
+  const display = useUIStore((s) => s.showStats);
   const { total, increaseFactor } = calculateStats(scores);
 
   useClickOutside(statsRef, () => setVisibility('showStats', false), [statsButtonRef]);

--- a/front/src/components/Tab/Tab.tsx
+++ b/front/src/components/Tab/Tab.tsx
@@ -12,8 +12,9 @@ interface TabProps {
 }
 
 function Tab({ tabButtonRef }: TabProps): JSX.Element {
-  const { playerList } = useGameStore();
-  const { setVisibility, showTab: display } = useUIStore();
+  const playerList = useGameStore((s) => s.playerList);
+  const setVisibility = useUIStore((s) => s.setVisibility);
+  const display = useUIStore((s) => s.showTab);
 
   const tabRef = useRef<HTMLDivElement>(null);
 

--- a/front/src/hooks/keyboardEvents/useGameLogic.ts
+++ b/front/src/hooks/keyboardEvents/useGameLogic.ts
@@ -9,11 +9,18 @@ import { useWebSocketStore } from '../../stores/useWebSocketStore';
 import { Client } from '@surtom/interfaces';
 
 const useGameLogic = () => {
-  const { letters, setLetters, tries, addTry, solution, addAchievement, validWords, gameFinished } = useGameStore();
+  const letters = useGameStore((s) => s.letters);
+  const setLetters = useGameStore((s) => s.setLetters);
+  const tries = useGameStore((s) => s.tries);
+  const addTry = useGameStore((s) => s.addTry);
+  const solution = useGameStore((s) => s.solution);
+  const addAchievement = useGameStore((s) => s.addAchievement);
+  const validWords = useGameStore((s) => s.validWords);
+  const gameFinished = useGameStore((s) => s.gameFinished);
 
-  const { setVisibility } = useUIStore();
+  const setVisibility = useUIStore((s) => s.setVisibility);
   const skipFirstLetter = useRef(true);
-  const { sendMessage } = useWebSocketStore();
+  const sendMessage = useWebSocketStore((s) => s.sendMessage);
 
   useEffect(() => {
     if (!solution || gameFinished()) return;

--- a/front/src/hooks/keyboardEvents/useShortcuts.ts
+++ b/front/src/hooks/keyboardEvents/useShortcuts.ts
@@ -3,10 +3,9 @@ import useUIStore from '../../stores/useUIStore';
 import useChatStore from '../../stores/useChatStore';
 
 const useShortcuts = () => {
-  const { setVisibility } = useUIStore();
-
-  const showChat = useUIStore((state) => state.showChat);
-  const { focusInput } = useChatStore();
+  const setVisibility = useUIStore((s) => s.setVisibility);
+  const showChat = useUIStore((s) => s.showChat);
+  const focusInput = useChatStore((s) => s.focusInput);
   const showChatRef = useRef(showChat);
 
   useEffect(() => {

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -8,7 +8,7 @@ import useGameStore from './stores/useGameStore';
 const RootComponent = () => {
   const [haveAssetsLoaded, setHaveAssetsLoaded] = useState(true);
   const [showLoading, setShowLoading] = useState(true);
-  const { hasLoaded: hasReceivedDailyWords } = useGameStore();
+  const hasReceivedDailyWords = useGameStore((s) => s.hasLoaded);
 
   useEffect(() => {
     if (haveAssetsLoaded && hasReceivedDailyWords) {

--- a/front/src/utils/webSocketPingHandler.ts
+++ b/front/src/utils/webSocketPingHandler.ts
@@ -3,7 +3,8 @@ import { useWebSocketStore } from '../stores/useWebSocketStore';
 import { Client } from '@surtom/interfaces';
 
 const WebSocketPingHandler = () => {
-  const { isConnected, sendMessage } = useWebSocketStore();
+  const isConnected = useWebSocketStore((s) => s.isConnected);
+  const sendMessage = useWebSocketStore((s) => s.sendMessage);
 
   useEffect(() => {
     if (!isConnected) return;


### PR DESCRIPTION
Many components destructured entire Zustand stores, subscribing them to every field change and triggering needless re-renders; switching each call site to per-field selectors limits re-renders to the fields actually consumed.