### PR TITLE
fix:(perf) memoize chat messages render and reuse Intl.DateTimeFormat

### DIFF
--- a/front/src/components/Chat/MessagesBox/Messages.tsx
+++ b/front/src/components/Chat/MessagesBox/Messages.tsx
@@ -1,4 +1,4 @@
-import { JSX, useCallback, useEffect, useRef } from 'react';
+import { JSX, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Server } from '@surtom/interfaces';
 import Message from './Message/Message';
 import classes from './Messages.module.css';
@@ -9,8 +9,16 @@ interface MessagesBoxProps {
   onCloseToBottom?: (isNearBottom: boolean) => void;
 }
 
+const NEAR_BOTTOM_THRESHOLD = 150;
+
+const dateFormatter = new Intl.DateTimeFormat('fr', {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
 function MessagesBox({ messages, onCloseToBottom }: MessagesBoxProps): JSX.Element {
-  const NEAR_BOTTOM_THRESHOLD = 150;
   const containerRef = useRef<HTMLDivElement>(null);
   const setScrollToBottom = useChatStore((state) => state.setScrollToBottom);
 
@@ -25,55 +33,55 @@ function MessagesBox({ messages, onCloseToBottom }: MessagesBoxProps): JSX.Eleme
     setScrollToBottom(scrollToBottom);
   }, [setScrollToBottom, scrollToBottom]);
 
-  const handleScroll = () => {
-    if (!onCloseToBottom || !containerRef.current) return;
+  const onCloseToBottomRef = useRef(onCloseToBottom);
+  onCloseToBottomRef.current = onCloseToBottom;
+
+  const handleScroll = useCallback(() => {
+    if (!onCloseToBottomRef.current || !containerRef.current) return;
     const { scrollTop } = containerRef.current;
     const isNearBottom = scrollTop > -NEAR_BOTTOM_THRESHOLD;
 
-    onCloseToBottom(isNearBottom);
-  };
+    onCloseToBottomRef.current(isNearBottom);
+  }, []);
 
-  const renderedMessages: JSX.Element[] = [];
-  let prevDate: string | null = null;
+  const renderedMessages = useMemo(() => {
+    const out: JSX.Element[] = [];
+    let prevDate: string | null = null;
+    const reversed = messages.slice().reverse();
 
-  const reversed = [...messages].reverse();
+    for (let i = 0; i < reversed.length; i++) {
+      const msg = reversed[i];
+      const hasTimestamp = 'timestamp' in msg.content;
+      const id = `${hasTimestamp ? msg.content.timestamp : 'no-ts'}-${msg.type}-${'id' in msg.content ? msg.content.id : 'no-id'}`;
 
-  for (let i = 0; i < reversed.length; i++) {
-    const msg = reversed[i];
-    const hasTimestamp = 'timestamp' in msg.content;
-    const id = `${hasTimestamp ? msg.content.timestamp : 'no-ts'}-${msg.type}-${'id' in msg.content ? msg.content.id : 'no-id'}`;
+      let dateSeparator: JSX.Element | null = null;
 
-    let dateSeparator: JSX.Element | null = null;
+      if (hasTimestamp) {
+        const currentDate = dateFormatter.format(new Date(msg.content.timestamp));
 
-    if (hasTimestamp) {
-      const currentDate = new Date(msg.content.timestamp).toLocaleDateString('fr', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      });
+        if (prevDate && currentDate !== prevDate) {
+          dateSeparator = (
+            <div key={`date-${id}`} className={classes.date} data-key={`date-${id}`}>
+              <span className={classes.dateLeftBar}></span>
+              {prevDate}
+              <span className={classes.dateRightBar}></span>
+            </div>
+          );
+        }
 
-      if (prevDate && currentDate !== prevDate) {
-        dateSeparator = (
-          <div key={`date-${id}`} className={classes.date} data-key={`date-${id}`}>
-            <span className={classes.dateLeftBar}></span>
-            {prevDate}
-            <span className={classes.dateRightBar}></span>
-          </div>
-        );
+        prevDate = currentDate;
       }
 
-      prevDate = currentDate;
+      if (dateSeparator) out.push(dateSeparator);
+
+      out.push(
+        <div key={id} data-key={id} {...('id' in msg.content && { 'data-id': msg.content.id })}>
+          <Message message={msg} />
+        </div>,
+      );
     }
-
-    if (dateSeparator) renderedMessages.push(dateSeparator);
-
-    renderedMessages.push(
-      <div key={id} data-key={id} {...('id' in msg.content && { 'data-id': msg.content.id })}>
-        <Message message={msg} />
-      </div>,
-    );
-  }
+    return out;
+  }, [messages]);
 
   return (
     <div ref={containerRef} className={classes.messages} onScroll={handleScroll}>


### PR DESCRIPTION
MessagesBox rebuilt the entire reversed list and instantiated an Intl.DateTimeFormat per message on every render; useMemo over messages plus a single shared formatter avoids both costs.