### PR TITLE
fix:(perf) pre-lowercase emoji and player suggestion labels

### DIFF
--- a/front/src/components/Chat/ChatInput/useInputSuggestions.ts
+++ b/front/src/components/Chat/ChatInput/useInputSuggestions.ts
@@ -7,28 +7,46 @@ export type Suggestion = {
   value: string;
 };
 
-type Trigger = {
-  char: string;
-  getSuggestions: () => Suggestion[];
+type IndexedSuggestion = Suggestion & {
+  labelLower: string;
+  valueLower: string;
 };
 
-const EMOJI_SUGGESTIONS: Suggestion[] = (discordEmojis as { emojis: { names: string[]; surrogates: string }[] }).emojis.flatMap((entry) =>
-  entry.names.map((name) => ({
-    label: `${entry.surrogates} :${name}:`,
-    value: entry.surrogates,
-  })),
+type Trigger = {
+  char: string;
+  getSuggestions: () => IndexedSuggestion[];
+};
+
+const EMOJI_SUGGESTIONS: IndexedSuggestion[] = (discordEmojis as { emojis: { names: string[]; surrogates: string }[] }).emojis.flatMap(
+  (entry) =>
+    entry.names.map((name) => {
+      const label = `${entry.surrogates} :${name}:`;
+      const value = entry.surrogates;
+      return {
+        label,
+        value,
+        labelLower: label.toLowerCase(),
+        valueLower: value.toLowerCase(),
+      };
+    }),
 );
 
-function getEmojiSuggestions(): Suggestion[] {
+function getEmojiSuggestions(): IndexedSuggestion[] {
   return EMOJI_SUGGESTIONS;
 }
 
-function getPlayerSuggestions(): Suggestion[] {
+function getPlayerSuggestions(): IndexedSuggestion[] {
   const players = useGameStore.getState().playerList;
-  return players.map((p) => ({
-    label: p.name,
-    value: `@${p.name}`,
-  }));
+  return players.map((p) => {
+    const label = p.name;
+    const value = `@${p.name}`;
+    return {
+      label,
+      value,
+      labelLower: label.toLowerCase(),
+      valueLower: value.toLowerCase(),
+    };
+  });
 }
 
 const TRIGGERS: Trigger[] = [
@@ -55,9 +73,8 @@ export function matchTrigger(text: string, cursorPos: number): ActiveSuggestion 
     if (query.includes(' ') && char === ':') continue;
 
     const all = getSuggestions();
-    const filtered = query
-      ? all.filter((s) => s.label.toLowerCase().includes(query.toLowerCase()) || s.value.toLowerCase().includes(query.toLowerCase()))
-      : all;
+    const queryLower = query.toLowerCase();
+    const filtered = query ? all.filter((s) => s.labelLower.includes(queryLower) || s.valueLower.includes(queryLower)) : all;
 
     if (filtered.length === 0) continue;
 


### PR DESCRIPTION
Filtering 1.5k emoji suggestions previously called toLowerCase on every label and value for every keystroke; precomputing the lowercased forms once cuts that work to a single pass.