### PR TITLE
fix:(perf) scope CustomContextMenu close listener to visible state

### DIFF
--- a/front/src/components/CustomContextMenu/CustomContextMenu.tsx
+++ b/front/src/components/CustomContextMenu/CustomContextMenu.tsx
@@ -22,9 +22,14 @@ function CustomContextMenu({ children, menuContent, offset = 10 }: CustomContext
     setPosition(getTooltipPosition({ x: event.clientX, y: event.clientY }, menuRef.current, offset, Anchor.BOTTOM_RIGHT));
   }, [visible, event, offset]);
 
-  const closeMenu = () => {
-    setVisible(false);
-  };
+  useEffect(() => {
+    if (!visible) return;
+    const closeMenu = () => setVisible(false);
+    document.addEventListener('click', closeMenu);
+    return () => {
+      document.removeEventListener('click', closeMenu);
+    };
+  }, [visible]);
 
   return (
     <span
@@ -33,7 +38,6 @@ function CustomContextMenu({ children, menuContent, offset = 10 }: CustomContext
         e.preventDefault();
         setEvent(e);
         setVisible(true);
-        document.addEventListener('click', closeMenu, { once: true });
       }}
     >
       {children}


### PR DESCRIPTION
Each right-click attached a new document click handler that was never cleaned up on unmount; moving the listener into a useEffect tied to the visible flag guarantees a single live handler and proper teardown.