### PR TITLE
test(back): add unit tests covering refactored backend

### DIFF
--- a/back/jest.config.cjs
+++ b/back/jest.config.cjs
@@ -4,10 +4,16 @@ module.exports = {
   passWithNoTests: true,
   moduleFileExtensions: ['ts', 'js'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: { module: 'commonjs', target: 'ES2020', esModuleInterop: true, strict: true, skipLibCheck: true } },
+    ],
+    '^.+\\.jsx?$': ['babel-jest', { presets: [['@babel/preset-env', { targets: { node: 'current' } }]] }],
   },
+  transformIgnorePatterns: ['/node_modules/(?!(@surtom/interfaces)/)'],
   testRegex: '(/__tests__/.*|(\\.|/)(critical|integration|test|spec))\\.tsx?$',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/back/package.json
+++ b/back/package.json
@@ -9,6 +9,9 @@
   },
   "dependencies": {
     "@surtom/interfaces": "1.0.0",
+    "@types/bcrypt": "^5.0.2",
+    "@types/node": "^22.13.4",
+    "@types/ws": "^8.18.0",
     "axios": "^1.7.2",
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",
@@ -16,13 +19,13 @@
     "readline": "^1.3.0",
     "sequelize-auto": "^0.8.8",
     "typescript": "^5.7.3",
-    "ws": "^8.17.0",
-    "@types/bcrypt": "^5.0.2",
-    "@types/node": "^22.13.4",
-    "@types/ws": "^8.18.0"
+    "ws": "^8.17.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.2",
     "@types/jest": "^29.5.14",
+    "babel-jest": "^30.3.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",
     "ts-jest": "^29.2.5",

--- a/back/src/commands/addtype.test.ts
+++ b/back/src/commands/addtype.test.ts
@@ -1,0 +1,61 @@
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendSuccess: jest.fn(),
+}));
+
+import { sendError, sendSuccess } from '../ws/send.js';
+import { handleAddTypeCommand } from './addtype.js';
+
+const fakeWs = {} as never;
+
+const buildUser = () =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel: 1,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleAddTypeCommand', () => {
+  it('appends a valid type and acknowledges success', async () => {
+    const user = buildUser();
+    await handleAddTypeCommand(user, ['addtype', 'cursor']);
+    expect(user.listeningTypes).toEqual(['cursor']);
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Vous écoutez maintenant le type : cursor');
+  });
+
+  it('rejects invalid types', async () => {
+    const user = buildUser();
+    await handleAddTypeCommand(user, ['addtype', 'bad type!']);
+    expect(user.listeningTypes).toEqual([]);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Type invalide');
+  });
+
+  it('lists the current listening types when called with no args', async () => {
+    const user = buildUser();
+    user.listeningTypes.push('a', 'b');
+    await handleAddTypeCommand(user, ['addtype']);
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Vous écoutez les types : a, b');
+  });
+
+  it('rejects when too many args are provided', async () => {
+    const user = buildUser();
+    await handleAddTypeCommand(user, ['addtype', 'a', 'b']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /listen type');
+  });
+});

--- a/back/src/commands/eval.test.ts
+++ b/back/src/commands/eval.test.ts
@@ -1,0 +1,62 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('./targeting.js', () => ({
+  __esModule: true,
+  getTargetedUsers: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { getTargetedUsers } from './targeting.js';
+import { sendError, sendToUser } from '../ws/send.js';
+import { handleEvalCommand } from './eval.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (moderatorLevel = 0) =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'someone',
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleEvalCommand', () => {
+  it('refuses non-moderators', async () => {
+    await handleEvalCommand(buildUser(0), ['eval', '@a', 'alert(1)']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, '¿¿¿¿¿¿¿¿¿¿¿¿¿¿¿');
+  });
+
+  it('reports usage when too few args are given', async () => {
+    await handleEvalCommand(buildUser(2), ['eval', '@a']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /eval pseudo ¿¿¿¿¿');
+  });
+
+  it('blocks any payload referencing cookies', async () => {
+    await handleEvalCommand(buildUser(2), ['eval', '@a', 'document.cookie']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Pas touche aux 🍪 !');
+  });
+
+  it('sends an EVAL message to each targeted user', async () => {
+    const target = buildUser(0);
+    (getTargetedUsers as jest.Mock).mockReturnValue([target]);
+    await handleEvalCommand(buildUser(2), ['eval', '@a', 'alert(1)']);
+    expect(sendToUser).toHaveBeenCalledWith(fakeWs, { type: Server.MessageType.EVAL, content: 'alert(1)' });
+  });
+});

--- a/back/src/commands/help/availableCommands.test.ts
+++ b/back/src/commands/help/availableCommands.test.ts
@@ -1,0 +1,22 @@
+import { getAvailableCommands } from './availableCommands.js';
+
+describe('getAvailableCommands', () => {
+  it('returns the base 4 commands plus /refresh for non-moderators', () => {
+    const cmds = getAvailableCommands(false);
+    expect(Object.keys(cmds)).toEqual(
+      expect.arrayContaining(['/register pseudo mot_de_passe', '/login pseudo mot_de_passe', '/msg cible message', '/help', '/refresh']),
+    );
+  });
+
+  it('exposes the moderator-only commands when isModerator=true', () => {
+    const cmds = getAvailableCommands(true);
+    expect(Object.keys(cmds)).toEqual(expect.arrayContaining(['/refresh cible?', '/mod mot_de_passe', '/addtype type', '/eval ¿¿¿ ¿¿¿¿']));
+  });
+
+  it('does not expose moderator commands to non-moderators', () => {
+    const cmds = getAvailableCommands(false);
+    expect(cmds['/mod mot_de_passe']).toBeUndefined();
+    expect(cmds['/addtype type']).toBeUndefined();
+    expect(cmds['/eval ¿¿¿ ¿¿¿¿']).toBeUndefined();
+  });
+});

--- a/back/src/commands/help/handler.test.ts
+++ b/back/src/commands/help/handler.test.ts
@@ -1,0 +1,59 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../../models/FullUser.js';
+
+jest.mock('../../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { sendError, sendToUser } from '../../ws/send.js';
+import { handleHelpCommand } from './handler.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (moderatorLevel = 0) =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleHelpCommand', () => {
+  it('rejects when extra args are passed', () => {
+    handleHelpCommand(buildUser(), ['help', 'extra']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /help');
+  });
+
+  it('sends an ENHANCED help message containing every available command for non-moderators', () => {
+    handleHelpCommand(buildUser(0), ['help']);
+    expect(sendToUser).toHaveBeenCalled();
+    const message = (sendToUser as jest.Mock).mock.calls[0][1];
+    expect(message.type).toBe(Server.MessageType.MESSAGE);
+    expect(message.content.type).toBe(Server.MessageType.ENHANCED);
+    const text = message.content.content.text;
+    expect(text).toContain('/login pseudo mot_de_passe');
+    expect(text).toContain('/help');
+    expect(text).not.toContain('/eval');
+  });
+
+  it('includes moderator commands when the user is a moderator', () => {
+    handleHelpCommand(buildUser(2), ['help']);
+    const text = (sendToUser as jest.Mock).mock.calls[0][1].content.content.text;
+    expect(text).toContain('/eval');
+    expect(text).toContain('/addtype');
+  });
+});

--- a/back/src/commands/index.test.ts
+++ b/back/src/commands/index.test.ts
@@ -1,0 +1,95 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('./nick.js', () => ({ __esModule: true, handleNickCommand: jest.fn() }));
+jest.mock('./login.js', () => ({ __esModule: true, handleLoginCommand: jest.fn() }));
+jest.mock('./register.js', () => ({ __esModule: true, handleRegisterCommand: jest.fn() }));
+jest.mock('./msg.js', () => ({ __esModule: true, handleMsgCommand: jest.fn() }));
+jest.mock('./eval.js', () => ({ __esModule: true, handleEvalCommand: jest.fn() }));
+jest.mock('./addtype.js', () => ({ __esModule: true, handleAddTypeCommand: jest.fn() }));
+jest.mock('./refresh.js', () => ({ __esModule: true, handleRefreshCommand: jest.fn() }));
+jest.mock('./tellraw.js', () => ({ __esModule: true, handleTellrawCommand: jest.fn() }));
+jest.mock('./help/handler.js', () => ({ __esModule: true, handleHelpCommand: jest.fn() }));
+jest.mock('./secret.js', () => ({
+  __esModule: true,
+  findSecretCommand: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { handleNickCommand } from './nick.js';
+import { handleLoginCommand } from './login.js';
+import { handleRegisterCommand } from './register.js';
+import { handleMsgCommand } from './msg.js';
+import { handleEvalCommand } from './eval.js';
+import { handleAddTypeCommand } from './addtype.js';
+import { handleRefreshCommand } from './refresh.js';
+import { handleTellrawCommand } from './tellraw.js';
+import { handleHelpCommand } from './help/handler.js';
+import { findSecretCommand } from './secret.js';
+import { sendError, sendToUser } from '../ws/send.js';
+import { handleCommand } from './index.js';
+
+const fakeWs = {} as never;
+
+const buildUser = () =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel: 0,
+      isLoggedIn: false,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleCommand router', () => {
+  const cases: Array<[string, jest.Mock]> = [
+    ['nick foo', handleNickCommand as jest.Mock],
+    ['login a b', handleLoginCommand as jest.Mock],
+    ['register a b', handleRegisterCommand as jest.Mock],
+    ['msg a hi', handleMsgCommand as jest.Mock],
+    ['eval @a alert(1)', handleEvalCommand as jest.Mock],
+    ['addtype cursor', handleAddTypeCommand as jest.Mock],
+    ['refresh', handleRefreshCommand as jest.Mock],
+    ['tellraw {}', handleTellrawCommand as jest.Mock],
+    ['help', handleHelpCommand as jest.Mock],
+  ];
+
+  it.each(cases)('routes %s to its handler', async (input, mock) => {
+    await handleCommand(buildUser(), input);
+    expect(mock).toHaveBeenCalledWith(expect.any(Object), input.split(' '));
+  });
+
+  it('is case-insensitive on the command name', async () => {
+    await handleCommand(buildUser(), 'LoGiN a b');
+    expect(handleLoginCommand).toHaveBeenCalled();
+  });
+
+  it('falls back to a secret command when present', async () => {
+    (findSecretCommand as jest.Mock).mockReturnValue({ hash: '$2x', payload: 'do({{command}})' });
+    await handleCommand(buildUser(), 'topsecret arg');
+    expect(sendToUser).toHaveBeenCalledWith(fakeWs, {
+      type: Server.MessageType.EVAL,
+      content: 'do(topsecret)',
+    });
+  });
+
+  it('reports an unknown command when no handler and no secret matches', async () => {
+    (findSecretCommand as jest.Mock).mockReturnValue(undefined);
+    await handleCommand(buildUser(), 'doesnotexist');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Commande invalide !');
+  });
+});

--- a/back/src/commands/login.test.ts
+++ b/back/src/commands/login.test.ts
@@ -1,0 +1,52 @@
+import FullUser from '../models/FullUser.js';
+
+jest.mock('./session.js', () => ({
+  __esModule: true,
+  loginUserAndSendSession: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+}));
+
+import { loginUserAndSendSession } from './session.js';
+import { sendError } from '../ws/send.js';
+import { handleLoginCommand } from './login.js';
+
+const fakeWs = {} as never;
+
+const buildUser = () =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel: 0,
+      isLoggedIn: false,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleLoginCommand', () => {
+  it('forwards a 3-part command to loginUserAndSendSession', async () => {
+    const user = buildUser();
+    await handleLoginCommand(user, ['login', 'alice', 'pw']);
+    expect(loginUserAndSendSession).toHaveBeenCalledWith(user, 'alice', 'pw');
+    expect(sendError).not.toHaveBeenCalled();
+  });
+
+  it('returns the usage error when the wrong number of args is given', async () => {
+    const user = buildUser();
+    await handleLoginCommand(user, ['login']);
+    expect(loginUserAndSendSession).not.toHaveBeenCalled();
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /login pseudo mot_de_passe');
+  });
+});

--- a/back/src/commands/msg.test.ts
+++ b/back/src/commands/msg.test.ts
@@ -1,0 +1,71 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('./targeting.js', () => ({
+  __esModule: true,
+  getTargetedUsers: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { getTargetedUsers } from './targeting.js';
+import { sendError, sendToUser } from '../ws/send.js';
+import { handleMsgCommand } from './msg.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (name = 'sender', moderatorLevel = 0) =>
+  new FullUser(
+    `id-${name}`,
+    {
+      name,
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleMsgCommand', () => {
+  it('reports usage when too few args are given', async () => {
+    await handleMsgCommand(buildUser(), ['msg', 'alice']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /msg pseudo message');
+  });
+
+  it('does nothing when no targets are returned', async () => {
+    (getTargetedUsers as jest.Mock).mockReturnValue([]);
+    await handleMsgCommand(buildUser(), ['msg', 'nope', 'hello']);
+    expect(sendToUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid text from non-moderators', async () => {
+    (getTargetedUsers as jest.Mock).mockReturnValue([buildUser('target')]);
+    await handleMsgCommand(buildUser('sender', 0), ['msg', 'target', '']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Pseudo ou message invalide');
+  });
+
+  it('sends a private message to the target and an echo to the sender', async () => {
+    const target = buildUser('target');
+    (getTargetedUsers as jest.Mock).mockReturnValue([target]);
+    const sender = buildUser('sender');
+    await handleMsgCommand(sender, ['msg', 'target', 'hello', 'world']);
+
+    expect(sendToUser).toHaveBeenCalledTimes(2);
+    const calls = (sendToUser as jest.Mock).mock.calls;
+    const messages = calls.map(([, m]) => m);
+    expect(messages.every((m) => m.type === Server.MessageType.MESSAGE)).toBe(true);
+    expect(messages.every((m) => m.content.type === Server.MessageType.PRIVATE_MESSAGE)).toBe(true);
+    expect(messages.every((m) => m.content.content.text === 'hello world')).toBe(true);
+  });
+});

--- a/back/src/commands/nick.test.ts
+++ b/back/src/commands/nick.test.ts
@@ -1,0 +1,32 @@
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+}));
+
+import { sendError } from '../ws/send.js';
+import { handleNickCommand } from './nick.js';
+
+const fakeWs = {} as never;
+
+describe('handleNickCommand', () => {
+  it('always replies with the legacy refusal message', async () => {
+    const user = new FullUser(
+      'id-1',
+      {
+        name: 'alice',
+        moderatorLevel: 0,
+        isLoggedIn: false,
+        isMobile: false,
+        words: [],
+        isBanned: false,
+        xp: 0,
+      },
+      fakeWs,
+      'ip',
+    );
+    await handleNickCommand(user);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Eh non pardi ! Les temps ont changé...');
+  });
+});

--- a/back/src/commands/refresh.test.ts
+++ b/back/src/commands/refresh.test.ts
@@ -1,0 +1,98 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('./targeting.js', () => ({
+  __esModule: true,
+  getTargetedUsers: jest.fn(),
+}));
+jest.mock('../repositories/messageRepository.js', () => ({
+  __esModule: true,
+  getMessages: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendSuccess: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { getTargetedUsers } from './targeting.js';
+import { getMessages } from '../repositories/messageRepository.js';
+import { sendError, sendSuccess, sendToUser } from '../ws/send.js';
+import { handleRefreshCommand } from './refresh.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (moderatorLevel = 0) =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+const buildSavedTextMessage = (id: string): Server.ChatMessage.SavedType => ({
+  type: Server.MessageType.TEXT,
+  content: {
+    id,
+    user: { name: 'a', moderatorLevel: 0 },
+    text: 'msg',
+    timestamp: 'now',
+    deleted: 0,
+  },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleRefreshCommand', () => {
+  it('refreshes only the requester when called without args', async () => {
+    (getMessages as jest.Mock).mockResolvedValue([buildSavedTextMessage('1')]);
+    const user = buildUser(0);
+    await handleRefreshCommand(user, ['refresh']);
+    expect(sendToUser).toHaveBeenCalledWith(fakeWs, expect.objectContaining({ type: Server.MessageType.GET_MESSAGES }));
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Tchat rafraîchi');
+  });
+
+  it('refuses targeting from non-moderators', async () => {
+    await handleRefreshCommand(buildUser(0), ['refresh', '@a']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Vous n'êtes pas autorisé à utiliser cette commande.");
+    expect(getMessages).not.toHaveBeenCalled();
+  });
+
+  it('uses targeting for moderators', async () => {
+    const target = buildUser(0);
+    (getTargetedUsers as jest.Mock).mockReturnValue([target]);
+    (getMessages as jest.Mock).mockResolvedValue([buildSavedTextMessage('1')]);
+    await handleRefreshCommand(buildUser(2), ['refresh', '@a']);
+    expect(getTargetedUsers).toHaveBeenCalledWith('@a', expect.any(Object));
+    expect(sendToUser).toHaveBeenCalled();
+  });
+
+  it('reports usage on too many args', async () => {
+    await handleRefreshCommand(buildUser(0), ['refresh', '@a', 'extra']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /refresh target?');
+  });
+
+  it('filters out non-text/enhanced/score messages from the GET_MESSAGES payload', async () => {
+    (getMessages as jest.Mock).mockResolvedValue([
+      buildSavedTextMessage('1'),
+      {
+        type: Server.MessageType.PRIVATE_MESSAGE,
+        content: { id: '2', user: { name: 'a', moderatorLevel: 0 }, text: 'pm', timestamp: 'now', deleted: 0 },
+      },
+    ]);
+    await handleRefreshCommand(buildUser(0), ['refresh']);
+    const call = (sendToUser as jest.Mock).mock.calls.find(([, m]) => m.type === Server.MessageType.GET_MESSAGES);
+    expect(call?.[1].content).toHaveLength(1);
+  });
+});

--- a/back/src/commands/register.test.ts
+++ b/back/src/commands/register.test.ts
@@ -1,0 +1,75 @@
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../repositories/playerRepository.js', () => ({
+  __esModule: true,
+  registerPlayer: jest.fn(),
+  getPlayerByName: jest.fn(),
+}));
+jest.mock('./session.js', () => ({
+  __esModule: true,
+  applyLoginSession: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+}));
+
+import { registerPlayer, getPlayerByName } from '../repositories/playerRepository.js';
+import { applyLoginSession } from './session.js';
+import { sendError } from '../ws/send.js';
+import { handleRegisterCommand } from './register.js';
+
+const fakeWs = {} as never;
+
+const buildUser = () =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel: 0,
+      isLoggedIn: false,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleRegisterCommand', () => {
+  it('reports usage on the wrong number of args', async () => {
+    await handleRegisterCommand(buildUser(), ['register', 'alice']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisation : /register pseudo mot_de_passe');
+  });
+
+  it('rejects an invalid username', async () => {
+    await handleRegisterCommand(buildUser(), ['register', 'bad name!', 'pw']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Ce pseudo n'est pas disponible...");
+    expect(registerPlayer).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the username collides with a funny name', async () => {
+    await handleRegisterCommand(buildUser(), ['register', 'Surtomien', 'pw']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Ce pseudo n'est pas disponible...");
+  });
+
+  it('persists the player and starts a session on success', async () => {
+    (registerPlayer as jest.Mock).mockResolvedValue(undefined);
+    (getPlayerByName as jest.Mock).mockResolvedValue({ id: 1, username: 'newcomer', isAdmin: 0, isBanned: 0 });
+    const user = buildUser();
+    await handleRegisterCommand(user, ['register', 'newcomer', 'pw']);
+    expect(registerPlayer).toHaveBeenCalledWith('newcomer', 'pw');
+    expect(applyLoginSession).toHaveBeenCalledWith(user, expect.objectContaining({ username: 'newcomer' }), 'Bienvenue newcomer !');
+  });
+
+  it('forwards repository errors via sendError', async () => {
+    (registerPlayer as jest.Mock).mockRejectedValue(new Error('Oups, pseudo déjà pris.'));
+    await handleRegisterCommand(buildUser(), ['register', 'taken', 'pw']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Oups, pseudo déjà pris.');
+  });
+});

--- a/back/src/commands/secret.test.ts
+++ b/back/src/commands/secret.test.ts
@@ -1,0 +1,21 @@
+import { findSecretCommand, secretCommands } from './secret.js';
+
+describe('secretCommands', () => {
+  it('exports at least one secret command', () => {
+    expect(secretCommands.length).toBeGreaterThan(0);
+  });
+
+  it('every secret has a hash and a payload containing the {{command}} placeholder', () => {
+    secretCommands.forEach((sc) => {
+      expect(typeof sc.hash).toBe('string');
+      expect(sc.hash.startsWith('$2')).toBe(true);
+      expect(sc.payload).toContain('{{command}}');
+    });
+  });
+});
+
+describe('findSecretCommand', () => {
+  it('returns undefined for an unknown name', () => {
+    expect(findSecretCommand('definitely-not-a-secret-command-xyz')).toBeUndefined();
+  });
+});

--- a/back/src/commands/session.test.ts
+++ b/back/src/commands/session.test.ts
@@ -1,0 +1,124 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../utils/crypto.js', () => ({
+  __esModule: true,
+  generateRandomHash: jest.fn(() => 'fixed-hash'),
+  passwordInHashArray: jest.fn(),
+}));
+jest.mock('../repositories/playerRepository.js', () => ({
+  __esModule: true,
+  storeSessionHash: jest.fn(),
+  loginPlayer: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendSuccess: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+jest.mock('../utils/ban.js', () => ({
+  __esModule: true,
+  handleIsBanned: jest.fn(),
+}));
+jest.mock('../state/eventBus.js', () => ({
+  __esModule: true,
+  publish: jest.fn(),
+  subscribe: jest.fn(),
+}));
+
+import { storeSessionHash, loginPlayer } from '../repositories/playerRepository.js';
+import { sendError, sendSuccess, sendToUser } from '../ws/send.js';
+import { handleIsBanned } from '../utils/ban.js';
+import { publish } from '../state/eventBus.js';
+import { applyLoginSession, loginUserAndSendSession } from './session.js';
+
+const fakeWs = {} as never;
+
+const buildUser = () =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'someone',
+      moderatorLevel: 0,
+      isLoggedIn: false,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+const buildPlayer = (
+  overrides: Partial<{ id: number; username: string; isAdmin: number; isBanned: number; sessionHash?: string }> = {},
+) => ({
+  id: 1,
+  username: 'alice',
+  password: 'pwhash',
+  registrationDate: new Date('2024-01-01'),
+  isAdmin: 0,
+  isBanned: 0,
+  sessionHash: undefined as string | undefined,
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('applyLoginSession', () => {
+  it('updates the privateUser, generates and stores a fresh session hash', async () => {
+    const user = buildUser();
+    await applyLoginSession(user, buildPlayer({ id: 7, username: 'alice', isAdmin: 1 }), 'Welcome');
+
+    expect(user.privateUser.name).toBe('alice');
+    expect(user.privateUser.moderatorLevel).toBe(1);
+    expect(user.privateUser.isLoggedIn).toBe(true);
+    expect(storeSessionHash).toHaveBeenCalledWith(7, 'fixed-hash');
+  });
+
+  it('reuses an existing session hash when present', async () => {
+    const user = buildUser();
+    await applyLoginSession(user, buildPlayer({ sessionHash: 'old-hash' }), 'Welcome');
+    expect(storeSessionHash).not.toHaveBeenCalled();
+    const sent = (sendToUser as jest.Mock).mock.calls[0][1];
+    expect(sent.content.sessionHash).toBe('old-hash');
+  });
+
+  it('sends LOGIN, success and publishes updateUsersList', async () => {
+    const user = buildUser();
+    await applyLoginSession(user, buildPlayer(), 'Welcome');
+
+    const loginCall = (sendToUser as jest.Mock).mock.calls.find(([, m]) => m.type === Server.MessageType.LOGIN);
+    expect(loginCall).toBeDefined();
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Welcome');
+    expect(publish).toHaveBeenCalledWith('updateUsersList');
+  });
+});
+
+describe('loginUserAndSendSession', () => {
+  it('returns false and shows the ban payload when the player is banned', async () => {
+    (loginPlayer as jest.Mock).mockResolvedValue(buildPlayer({ isBanned: 1 }));
+    const user = buildUser();
+    const ok = await loginUserAndSendSession(user, 'alice', 'pw');
+    expect(ok).toBe(false);
+    expect(handleIsBanned).toHaveBeenCalledWith(user);
+  });
+
+  it('returns true and sends a "Rebonjour" message on success', async () => {
+    (loginPlayer as jest.Mock).mockResolvedValue(buildPlayer({ username: 'alice' }));
+    const user = buildUser();
+    const ok = await loginUserAndSendSession(user, 'alice', 'pw');
+    expect(ok).toBe(true);
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Rebonjour alice !');
+  });
+
+  it('reports the error message on failure', async () => {
+    (loginPlayer as jest.Mock).mockRejectedValue(new Error('Mauvais mot de passe.'));
+    const ok = await loginUserAndSendSession(buildUser(), 'alice', 'pw');
+    expect(ok).toBe(false);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Mauvais mot de passe.');
+  });
+});

--- a/back/src/commands/targeting.test.ts
+++ b/back/src/commands/targeting.test.ts
@@ -1,0 +1,99 @@
+import FullUser from '../models/FullUser.js';
+import store from '../state/store.js';
+
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+}));
+
+import { sendError } from '../ws/send.js';
+import { getTargetedUsers } from './targeting.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (id: string, name: string) =>
+  new FullUser(
+    id,
+    {
+      name,
+      moderatorLevel: 0,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+const setUsers = (users: FullUser[]) => {
+  const map: Record<string, FullUser> = {};
+  users.forEach((u) => (map[u.id] = u));
+  store.setState({ users: map });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  store.setState({ users: {} });
+});
+
+describe('getTargetedUsers', () => {
+  it('returns every user for @a', () => {
+    const a = buildUser('1', 'a');
+    const b = buildUser('2', 'b');
+    setUsers([a, b]);
+    expect(getTargetedUsers('@a', a)).toHaveLength(2);
+  });
+
+  it('returns every user for @e', () => {
+    const a = buildUser('1', 'a');
+    const b = buildUser('2', 'b');
+    setUsers([a, b]);
+    expect(getTargetedUsers('@e', a)).toHaveLength(2);
+  });
+
+  it('returns the requester for @s', () => {
+    const a = buildUser('1', 'a');
+    setUsers([a]);
+    expect(getTargetedUsers('@s', a)).toEqual([a]);
+  });
+
+  it('returns one (random) user for @r', () => {
+    const a = buildUser('1', 'a');
+    const b = buildUser('2', 'b');
+    setUsers([a, b]);
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    expect(getTargetedUsers('@r', a)).toEqual([a]);
+    spy.mockReturnValue(0.99);
+    expect(getTargetedUsers('@r', a)).toEqual([b]);
+    spy.mockRestore();
+  });
+
+  it('matches a single user by exact name', () => {
+    const a = buildUser('1', 'alice');
+    const b = buildUser('2', 'bob');
+    setUsers([a, b]);
+    expect(getTargetedUsers('alice', a)).toEqual([a]);
+  });
+
+  it('strips a leading @ when looking up a user', () => {
+    const a = buildUser('1', 'alice');
+    setUsers([a]);
+    expect(getTargetedUsers('@alice', a)).toEqual([a]);
+  });
+
+  it('reports "Utilisateur inexistant" when nobody matches the name', () => {
+    const a = buildUser('1', 'alice');
+    setUsers([a]);
+    expect(getTargetedUsers('nope', a)).toEqual([]);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisateur inexistant');
+  });
+
+  it('rejects an invalid username', () => {
+    const a = buildUser('1', 'alice');
+    setUsers([a]);
+    expect(getTargetedUsers('bad name!', a)).toEqual([]);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Nom d'utilisateur invalide");
+  });
+});

--- a/back/src/commands/tellraw.test.ts
+++ b/back/src/commands/tellraw.test.ts
@@ -1,0 +1,72 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+import store from '../state/store.js';
+
+jest.mock('./targeting.js', () => ({
+  __esModule: true,
+  getTargetedUsers: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendSuccess: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { getTargetedUsers } from './targeting.js';
+import { sendError, sendSuccess, sendToUser } from '../ws/send.js';
+import { handleTellrawCommand } from './tellraw.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (name: string, moderatorLevel = 0) =>
+  new FullUser(
+    `id-${name}`,
+    {
+      name,
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  store.setState({ users: {} });
+});
+
+describe('handleTellrawCommand', () => {
+  it('refuses non-moderators', async () => {
+    await handleTellrawCommand(buildUser('alice', 0), ['tellraw', '{}']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Vous n'êtes pas autorisé à utiliser cette commande.");
+  });
+
+  it('rejects an invalid JSON payload', async () => {
+    await handleTellrawCommand(buildUser('mod', 2), ['tellraw', 'not-json']);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "L'objet JSON est invalide.");
+  });
+
+  it('broadcasts to every user when no target is given', async () => {
+    const a = buildUser('alice');
+    const b = buildUser('bob');
+    store.setState({ users: { 'id-alice': a, 'id-bob': b } });
+    await handleTellrawCommand(buildUser('mod', 2), ['tellraw', '{"text":"hi"}']);
+    expect(sendToUser).toHaveBeenCalledTimes(2);
+    const messages = (sendToUser as jest.Mock).mock.calls.map(([, m]) => m);
+    expect(messages.every((m) => m.type === Server.MessageType.MESSAGE && m.content.type === Server.MessageType.ENHANCED)).toBe(true);
+  });
+
+  it('uses targeting when a target is given', async () => {
+    const target = buildUser('alice');
+    (getTargetedUsers as jest.Mock).mockReturnValue([target]);
+    await handleTellrawCommand(buildUser('mod', 2), ['tellraw', 'alice', '{"text":"hi"}']);
+    expect(getTargetedUsers).toHaveBeenCalledWith('alice', expect.any(Object));
+    expect(sendToUser).toHaveBeenCalled();
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Message envoyé à alice');
+  });
+});

--- a/back/src/data/funnyNames.test.ts
+++ b/back/src/data/funnyNames.test.ts
@@ -1,0 +1,18 @@
+import { funnyNames } from './funnyNames.js';
+
+describe('funnyNames', () => {
+  it('is non-empty', () => {
+    expect(funnyNames.length).toBeGreaterThan(0);
+  });
+
+  it('contains only non-empty strings', () => {
+    funnyNames.forEach((name) => {
+      expect(typeof name).toBe('string');
+      expect(name.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('contains no duplicates', () => {
+    expect(new Set(funnyNames).size).toBe(funnyNames.length);
+  });
+});

--- a/back/src/handlers/chatHandler.test.ts
+++ b/back/src/handlers/chatHandler.test.ts
@@ -1,0 +1,171 @@
+import { Client, Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../repositories/messageRepository.js', () => ({
+  __esModule: true,
+  saveMessage: jest.fn(),
+}));
+jest.mock('../repositories/scoreRepository.js', () => ({
+  __esModule: true,
+  getDailyScore: jest.fn(),
+}));
+jest.mock('../repositories/wordRepository.js', () => ({
+  __esModule: true,
+  getTodaysWord: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+}));
+jest.mock('../ws/broadcast.js', () => ({
+  __esModule: true,
+  broadcastAll: jest.fn(),
+}));
+jest.mock('../utils/log.js', () => ({
+  __esModule: true,
+  logMessage: jest.fn(),
+}));
+
+import { saveMessage } from '../repositories/messageRepository.js';
+import { getDailyScore } from '../repositories/scoreRepository.js';
+import { getTodaysWord } from '../repositories/wordRepository.js';
+import { sendError } from '../ws/send.js';
+import { broadcastAll } from '../ws/broadcast.js';
+import { handleChatMessage } from './chatHandler.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (moderatorLevel = 0) =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+const buildSavedReply: Server.Message = {
+  type: Server.MessageType.MESSAGE,
+  content: {
+    type: Server.MessageType.TEXT,
+    content: {
+      id: '1',
+      user: { name: 'alice', moderatorLevel: 0 },
+      text: 'hi',
+      timestamp: 'now',
+      deleted: 0,
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleChatMessage (CHAT_MESSAGE)', () => {
+  it('rejects an empty/whitespace text from non-moderators without persisting', async () => {
+    const message: Client.ChatMessage = {
+      type: Client.MessageType.CHAT_MESSAGE,
+      content: { text: '   ' },
+    };
+    await handleChatMessage(buildUser(0), message);
+    expect(saveMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized image data even from moderators', async () => {
+    const message: Client.ChatMessage = {
+      type: Client.MessageType.CHAT_MESSAGE,
+      content: { text: 'hi', imageData: 'x'.repeat(200 * 1024) },
+    };
+    await handleChatMessage(buildUser(2), message);
+    expect(saveMessage).not.toHaveBeenCalled();
+  });
+
+  it('persists a valid chat message and broadcasts the saved reply', async () => {
+    (saveMessage as jest.Mock).mockResolvedValue(buildSavedReply);
+    const message: Client.ChatMessage = {
+      type: Client.MessageType.CHAT_MESSAGE,
+      content: { text: 'hello' },
+    };
+    await handleChatMessage(buildUser(0), message);
+    expect(saveMessage).toHaveBeenCalled();
+    expect(broadcastAll).toHaveBeenCalledWith(buildSavedReply);
+  });
+});
+
+describe('handleChatMessage (SCORE_TO_CHAT)', () => {
+  it('rejects when the user has already shared today', async () => {
+    (getDailyScore as jest.Mock).mockResolvedValue([['G', 'R', 'A', 'S', 'S']]);
+    await handleChatMessage(buildUser(), {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: [['G', 'R', 'A', 'S', 'S']] },
+    } as unknown as Client.ChatMessage);
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Vous avez déjà partagé votre score...');
+    expect(saveMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects when more than 6 attempts are submitted', async () => {
+    (getDailyScore as jest.Mock).mockResolvedValue([]);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await handleChatMessage(buildUser(), {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: Array.from({ length: 7 }, () => ['G', 'X', 'X', 'X', 'X']) },
+    } as unknown as Client.ChatMessage);
+    expect(saveMessage).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('rejects when no reference word can be found', async () => {
+    (getDailyScore as jest.Mock).mockResolvedValue([]);
+    (getTodaysWord as jest.Mock).mockResolvedValue(null);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await handleChatMessage(buildUser(), {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: [['G', 'R', 'A', 'S', 'S']] },
+    } as unknown as Client.ChatMessage);
+    expect(saveMessage).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('rejects attempts not matching the first letter or length of the reference', async () => {
+    (getDailyScore as jest.Mock).mockResolvedValue([]);
+    (getTodaysWord as jest.Mock).mockResolvedValue('GRASS');
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await handleChatMessage(buildUser(), {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: [['B', 'R', 'A', 'S', 'S']] },
+    } as unknown as Client.ChatMessage);
+    expect(saveMessage).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('persists and broadcasts a valid score', async () => {
+    (getDailyScore as jest.Mock).mockResolvedValue([]);
+    (getTodaysWord as jest.Mock).mockResolvedValue('GRASS');
+    (saveMessage as jest.Mock).mockResolvedValue(buildSavedReply);
+    await handleChatMessage(buildUser(), {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: [['G', 'R', 'A', 'S', 'S']] },
+    } as unknown as Client.ChatMessage);
+    expect(saveMessage).toHaveBeenCalled();
+    expect(broadcastAll).toHaveBeenCalledWith(buildSavedReply);
+  });
+
+  it('honors a custom solution when provided', async () => {
+    (getDailyScore as jest.Mock).mockResolvedValue([]);
+    (saveMessage as jest.Mock).mockResolvedValue(buildSavedReply);
+    await handleChatMessage(buildUser(), {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { custom: 'BRICK', attempts: [['B', 'R', 'I', 'C', 'K']] },
+    } as unknown as Client.ChatMessage);
+    expect(getTodaysWord).not.toHaveBeenCalled();
+    expect(broadcastAll).toHaveBeenCalled();
+  });
+});

--- a/back/src/handlers/cursorHandler.test.ts
+++ b/back/src/handlers/cursorHandler.test.ts
@@ -1,0 +1,41 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../ws/broadcast.js', () => ({
+  __esModule: true,
+  broadcastAllButSelf: jest.fn(),
+}));
+
+import { broadcastAllButSelf } from '../ws/broadcast.js';
+import { handleCursorPosition } from './cursorHandler.js';
+
+const fakeWs = {} as never;
+
+describe('handleCursorPosition', () => {
+  it('broadcasts the cursor position to everyone but the sender', () => {
+    const user = new FullUser(
+      'id-1',
+      {
+        name: 'alice',
+        moderatorLevel: 0,
+        isLoggedIn: true,
+        isMobile: false,
+        words: [],
+        isBanned: false,
+        xp: 0,
+      },
+      fakeWs,
+      'ip',
+    );
+
+    handleCursorPosition(user, { x: 12, y: 34 });
+
+    expect(broadcastAllButSelf).toHaveBeenCalledWith(user, {
+      type: Server.MessageType.CURSOR_POSITION,
+      content: {
+        user: { name: 'alice', moderatorLevel: 0, isMobile: false, isLoggedIn: true, xp: 0 },
+        cursor: { x: 12, y: 34 },
+      },
+    });
+  });
+});

--- a/back/src/handlers/deleteHandler.test.ts
+++ b/back/src/handlers/deleteHandler.test.ts
@@ -1,0 +1,91 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../repositories/messageRepository.js', () => ({
+  __esModule: true,
+  toggleMessage: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendToUser: jest.fn(),
+}));
+jest.mock('../ws/broadcast.js', () => ({
+  __esModule: true,
+  broadcastAll: jest.fn(),
+}));
+
+import { toggleMessage } from '../repositories/messageRepository.js';
+import { sendToUser } from '../ws/send.js';
+import { broadcastAll } from '../ws/broadcast.js';
+import { handleDeleteMessage } from './deleteHandler.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (moderatorLevel = 1) =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'mod',
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleDeleteMessage', () => {
+  it('does nothing when the user is not a moderator', async () => {
+    const user = buildUser(0);
+    await handleDeleteMessage(user, 1);
+    expect(toggleMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the message id is NaN', async () => {
+    const user = buildUser(1);
+    await handleDeleteMessage(user, NaN);
+    expect(toggleMessage).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts a DELETE_MESSAGE and acks success when toggle succeeds', async () => {
+    (toggleMessage as jest.Mock).mockResolvedValue(true);
+    const user = buildUser(1);
+    await handleDeleteMessage(user, 42);
+    expect(toggleMessage).toHaveBeenCalledWith(42, user.privateUser);
+    expect(broadcastAll).toHaveBeenCalledWith({
+      type: Server.MessageType.DELETE_MESSAGE,
+      content: 42,
+    });
+    expect(sendToUser).toHaveBeenCalledWith(
+      fakeWs,
+      expect.objectContaining({ type: Server.MessageType.LOG, content: expect.stringContaining('Successfully') }),
+    );
+  });
+
+  it('logs failure to the moderator when toggle returns false', async () => {
+    (toggleMessage as jest.Mock).mockResolvedValue(false);
+    const user = buildUser(1);
+    await handleDeleteMessage(user, 42);
+    expect(broadcastAll).not.toHaveBeenCalled();
+    expect(sendToUser).toHaveBeenCalledWith(
+      fakeWs,
+      expect.objectContaining({ type: Server.MessageType.LOG, content: expect.stringContaining('Failed') }),
+    );
+  });
+
+  it('swallows errors from the repository', async () => {
+    (toggleMessage as jest.Mock).mockRejectedValue(new Error('db down'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const user = buildUser(1);
+    await expect(handleDeleteMessage(user, 42)).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/back/src/handlers/tryHandler.test.ts
+++ b/back/src/handlers/tryHandler.test.ts
@@ -1,0 +1,126 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../repositories/playerRepository.js', () => ({
+  __esModule: true,
+  getPlayerByName: jest.fn(),
+}));
+jest.mock('../repositories/wordRepository.js', () => ({
+  __esModule: true,
+  getTodaysWordAndHistoryId: jest.fn(),
+}));
+jest.mock('../repositories/tryRepository.js', () => ({
+  __esModule: true,
+  getOrCreateTry: jest.fn(),
+  updateTry: jest.fn(),
+}));
+jest.mock('../repositories/xpRepository.js', () => ({
+  __esModule: true,
+  getPlayerXp: jest.fn(),
+}));
+jest.mock('../ws/send.js', () => ({
+  __esModule: true,
+  sendError: jest.fn(),
+  sendSuccess: jest.fn(),
+  sendToUser: jest.fn(),
+}));
+
+import { getPlayerByName } from '../repositories/playerRepository.js';
+import { getTodaysWordAndHistoryId } from '../repositories/wordRepository.js';
+import { getOrCreateTry, updateTry } from '../repositories/tryRepository.js';
+import { getPlayerXp } from '../repositories/xpRepository.js';
+import { sendError, sendSuccess, sendToUser } from '../ws/send.js';
+import { handleTryMessage } from './tryHandler.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (name = 'alice') =>
+  new FullUser(
+    'id-1',
+    {
+      name,
+      moderatorLevel: 0,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getPlayerByName as jest.Mock).mockResolvedValue({ id: 7, username: 'alice' });
+  (getTodaysWordAndHistoryId as jest.Mock).mockResolvedValue({ wordHistoryId: 1, todaysWord: 'GRASS' });
+  (getOrCreateTry as jest.Mock).mockResolvedValue({ attempts: [], win: false });
+  (getPlayerXp as jest.Mock).mockResolvedValue(123);
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.log as jest.Mock).mockRestore?.();
+});
+
+describe('handleTryMessage', () => {
+  it('rejects an empty attempt', async () => {
+    await handleTryMessage(buildUser(), '   ');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Tentative vide.');
+    expect(updateTry).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong-length attempt', async () => {
+    await handleTryMessage(buildUser(), 'GR');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Le mot doit faire 5 lettres.');
+  });
+
+  it('rejects an attempt that does not start with the right letter', async () => {
+    await handleTryMessage(buildUser(), 'BRASS');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Le mot doit commencer par 'G'.");
+  });
+
+  it('rejects when the user has already used 6 tries', async () => {
+    (getOrCreateTry as jest.Mock).mockResolvedValue({
+      attempts: Array.from({ length: 6 }, () => ['G', 'X', 'X', 'X', 'X']),
+      win: false,
+    });
+    await handleTryMessage(buildUser(), 'GRASS');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Nombre maximum de tentatives atteint.');
+  });
+
+  it('rejects when the user has already won', async () => {
+    (getOrCreateTry as jest.Mock).mockResolvedValue({ attempts: [['G', 'R', 'A', 'S', 'S']], win: true });
+    await handleTryMessage(buildUser(), 'GRASS');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, "Vous avez déjà trouvé le mot aujourd'hui !");
+  });
+
+  it('records a winning attempt, sends success and pushes XP', async () => {
+    await handleTryMessage(buildUser(), 'grass');
+    expect(updateTry).toHaveBeenCalledWith(7, 1, [['G', 'R', 'A', 'S', 'S']], true);
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Bravo, vous avez trouvé le mot !');
+    expect(sendToUser).toHaveBeenCalledWith(fakeWs, { type: Server.MessageType.XP, content: 123 });
+  });
+
+  it('records a losing attempt without sending XP if not the last try', async () => {
+    await handleTryMessage(buildUser(), 'GRAPE');
+    expect(updateTry).toHaveBeenCalledWith(7, 1, [['G', 'R', 'A', 'P', 'E']], false);
+    expect(sendSuccess).toHaveBeenCalledWith(fakeWs, 'Tentative enregistrée !');
+    expect(sendToUser).not.toHaveBeenCalled();
+  });
+
+  it('sends XP after the 6th non-winning attempt', async () => {
+    (getOrCreateTry as jest.Mock).mockResolvedValue({
+      attempts: Array.from({ length: 5 }, () => ['G', 'X', 'X', 'X', 'X']),
+      win: false,
+    });
+    await handleTryMessage(buildUser(), 'GRAPE');
+    expect(sendToUser).toHaveBeenCalledWith(fakeWs, { type: Server.MessageType.XP, content: 123 });
+  });
+
+  it('forwards repository errors via sendError', async () => {
+    (getPlayerByName as jest.Mock).mockResolvedValue(undefined);
+    await handleTryMessage(buildUser(), 'GRASS');
+    expect(sendError).toHaveBeenCalledWith(fakeWs, 'Utilisateur introuvable.');
+  });
+});

--- a/back/src/handlers/typingHandler.test.ts
+++ b/back/src/handlers/typingHandler.test.ts
@@ -1,0 +1,38 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../ws/broadcast.js', () => ({
+  __esModule: true,
+  broadcastAll: jest.fn(),
+}));
+
+import { broadcastAll } from '../ws/broadcast.js';
+import { handleIsTyping } from './typingHandler.js';
+
+const fakeWs = {} as never;
+
+describe('handleIsTyping', () => {
+  it("broadcasts the user's name to everyone", () => {
+    const user = new FullUser(
+      'id-1',
+      {
+        name: 'alice',
+        moderatorLevel: 0,
+        isLoggedIn: false,
+        isMobile: false,
+        words: [],
+        isBanned: false,
+        xp: 0,
+      },
+      fakeWs,
+      'ip',
+    );
+
+    handleIsTyping(user);
+
+    expect(broadcastAll).toHaveBeenCalledWith({
+      type: Server.MessageType.IS_TYPING,
+      content: 'alice',
+    });
+  });
+});

--- a/back/src/handlers/userListHandler.test.ts
+++ b/back/src/handlers/userListHandler.test.ts
@@ -1,0 +1,64 @@
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+import store from '../state/store.js';
+
+jest.mock('../ws/broadcast.js', () => ({
+  __esModule: true,
+  broadcastAll: jest.fn(),
+}));
+
+import { broadcastAll } from '../ws/broadcast.js';
+import { updateUsersList } from './userListHandler.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (id: string, name: string) =>
+  new FullUser(
+    id,
+    {
+      name,
+      moderatorLevel: 0,
+      isLoggedIn: false,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+describe('updateUsersList', () => {
+  beforeEach(() => {
+    (broadcastAll as jest.Mock).mockClear();
+    store.setState({ users: {} });
+  });
+
+  it('broadcasts a USER_LIST containing each unique user', () => {
+    store.setState({ users: { 'id-1': buildUser('id-1', 'alice'), 'id-2': buildUser('id-2', 'bob') } });
+    updateUsersList();
+
+    expect(broadcastAll).toHaveBeenCalledTimes(1);
+    const message = (broadcastAll as jest.Mock).mock.calls[0][0];
+    expect(message.type).toBe(Server.MessageType.USER_LIST);
+    const names = message.content.map((u: Server.User) => u.name).sort();
+    expect(names).toEqual(['alice', 'bob']);
+  });
+
+  it('skips users with an empty name', () => {
+    store.setState({ users: { 'id-1': buildUser('id-1', '') } });
+    updateUsersList();
+    expect((broadcastAll as jest.Mock).mock.calls[0][0].content).toEqual([]);
+  });
+
+  it('deduplicates by name when the same user is connected twice', () => {
+    store.setState({
+      users: {
+        'id-1': buildUser('id-1', 'alice'),
+        'id-2': buildUser('id-2', 'alice'),
+      },
+    });
+    updateUsersList();
+    expect((broadcastAll as jest.Mock).mock.calls[0][0].content).toHaveLength(1);
+  });
+});

--- a/back/src/models/FullUser.test.ts
+++ b/back/src/models/FullUser.test.ts
@@ -1,0 +1,37 @@
+import FullUser from './FullUser.js';
+import { COOLDOWN_INITIAL_SECONDS, COOLDOWN_MULTIPLIER } from '../config/constants.js';
+
+const fakeWs = {} as never;
+
+const buildPrivateUser = () => ({
+  name: 'alice',
+  moderatorLevel: 0,
+  isLoggedIn: false,
+  isMobile: false,
+  words: [],
+  isBanned: false,
+  xp: 0,
+});
+
+describe('FullUser', () => {
+  it('initializes its rate-limit fields with the configured defaults', () => {
+    const user = new FullUser('id-1', buildPrivateUser(), fakeWs, '127.0.0.1');
+    expect(user.messageCount).toBe(0);
+    expect(user.lastMessageTimestamp).toBeNull();
+    expect(user.messageCooldown).toBe(COOLDOWN_INITIAL_SECONDS);
+    expect(user.cooldownMultiplier).toBe(COOLDOWN_MULTIPLIER);
+    expect(user.listeningTypes).toEqual([]);
+  });
+
+  it('preserves identity, connection and IP', () => {
+    const user = new FullUser('id-1', buildPrivateUser(), fakeWs, '10.0.0.1');
+    expect(user.id).toBe('id-1');
+    expect(user.connection).toBe(fakeWs);
+    expect(user.ip).toBe('10.0.0.1');
+  });
+
+  it('defaults ip to "unknown" when not provided', () => {
+    const user = new FullUser('id-1', buildPrivateUser(), fakeWs);
+    expect(user.ip).toBe('unknown');
+  });
+});

--- a/back/src/repositories/messageRepository.test.ts
+++ b/back/src/repositories/messageRepository.test.ts
@@ -1,0 +1,217 @@
+import { Client, Server } from '@surtom/interfaces';
+
+jest.mock('./pool.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+jest.mock('./playerRepository.js', () => ({
+  __esModule: true,
+  getPlayerByName: jest.fn(),
+}));
+jest.mock('./wordRepository.js', () => ({
+  __esModule: true,
+  getTodaysWord: jest.fn(),
+}));
+
+import pool from './pool.js';
+import { getPlayerByName } from './playerRepository.js';
+import { getTodaysWord } from './wordRepository.js';
+import { getHelpMessage, getLastMessageTimestamp, getMessageById, getMessages, saveMessage, toggleMessage } from './messageRepository.js';
+
+const query = pool.query as unknown as jest.Mock;
+
+const buildJoinRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  ID: 1,
+  Username: 'alice',
+  Timestamp: '2024-01-01T00:00:00.000Z',
+  Type: 'TEXT',
+  Text: 'hi',
+  ImageData: null,
+  ReplyID: null,
+  Answer: null,
+  Attempts: null,
+  IsCustom: 0,
+  IsAdmin: 0,
+  Deleted: 0,
+  ...overrides,
+});
+
+beforeEach(() => {
+  query.mockReset();
+  (getPlayerByName as jest.Mock).mockReset();
+  (getTodaysWord as jest.Mock).mockReset();
+});
+
+describe('getHelpMessage', () => {
+  it('returns an ENHANCED System message', () => {
+    const help = getHelpMessage();
+    expect(help.type).toBe(Server.MessageType.ENHANCED);
+    expect(help.content.user.name).toBe('System');
+  });
+});
+
+describe('getMessages', () => {
+  it('orders messages chronologically (reverses the DESC query)', async () => {
+    query.mockResolvedValueOnce([
+      [buildJoinRow({ ID: 2, Timestamp: '2024-01-02T00:00:00.000Z' }), buildJoinRow({ ID: 1, Timestamp: '2024-01-01T00:00:00.000Z' })],
+    ]);
+    const msgs = await getMessages();
+    expect(msgs.map((m) => m.content.id)).toEqual(['1', '2']);
+  });
+
+  it('prepends the help message when showHelp=true (becomes last after reverse)', async () => {
+    query.mockResolvedValueOnce([[buildJoinRow()]]);
+    const msgs = await getMessages(false, 200, true);
+    expect(msgs[msgs.length - 1].content.user.name).toBe('System');
+  });
+
+  it('maps SCORE rows to a SCORE message', async () => {
+    query.mockResolvedValueOnce([
+      [
+        buildJoinRow({
+          Type: 'SCORE',
+          Text: null,
+          Answer: 'GRASS',
+          Attempts: JSON.stringify([['G', 'R', 'A', 'S', 'S']]),
+        }),
+      ],
+    ]);
+    const [msg] = await getMessages();
+    expect(msg.type).toBe(Server.MessageType.SCORE);
+    expect((msg.content as Server.ChatMessage.Content.ScoreMessageContent).answer).toBe('GRASS');
+  });
+});
+
+describe('getMessageById', () => {
+  it('returns undefined when the message does not exist', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getMessageById(1)).toBeUndefined();
+  });
+
+  it('returns the mapped message when found', async () => {
+    query.mockResolvedValueOnce([[buildJoinRow()]]);
+    expect((await getMessageById(1))?.content.id).toBe('1');
+  });
+});
+
+describe('getLastMessageTimestamp', () => {
+  it('returns null when no message exists', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getLastMessageTimestamp()).toBeNull();
+  });
+
+  it('returns the timestamp of the most recent message', async () => {
+    query.mockResolvedValueOnce([[{ Timestamp: '2024-01-01T00:00:00.000Z' }]]);
+    expect(await getLastMessageTimestamp()).toBe('2024-01-01T00:00:00.000Z');
+  });
+});
+
+describe('saveMessage (CHAT_MESSAGE)', () => {
+  it('throws when the player is not found', async () => {
+    (getPlayerByName as jest.Mock).mockResolvedValue(undefined);
+    await expect(
+      saveMessage(
+        { name: 'a', moderatorLevel: 0, isLoggedIn: true, isMobile: false, words: [], isBanned: false, xp: 0 },
+        { type: Client.MessageType.CHAT_MESSAGE, content: { text: 'hi' } },
+      ),
+    ).rejects.toThrow('Player not found');
+  });
+
+  it('inserts the message + text content and returns a TEXT envelope', async () => {
+    (getPlayerByName as jest.Mock).mockResolvedValue({ id: 7 });
+    query.mockResolvedValueOnce([{ insertId: 42 }]).mockResolvedValueOnce([{}]);
+    const out = await saveMessage(
+      { name: 'a', moderatorLevel: 0, isLoggedIn: true, isMobile: false, words: [], isBanned: false, xp: 0 },
+      { type: Client.MessageType.CHAT_MESSAGE, content: { text: 'hi', imageData: 'img', replyId: '5' } },
+    );
+    expect(query.mock.calls[1][0]).toMatch(/INSERT INTO TextContent/);
+    expect(query.mock.calls[1][1]).toEqual([42, 'hi', 'img', 5]);
+    expect(out.type).toBe(Server.MessageType.MESSAGE);
+    expect((out.content as Server.ChatMessage.SavedType).type).toBe(Server.MessageType.TEXT);
+  });
+});
+
+describe('saveMessage (SCORE_TO_CHAT)', () => {
+  it('uses the daily word when no custom solution is provided', async () => {
+    (getPlayerByName as jest.Mock).mockResolvedValue({ id: 1 });
+    (getTodaysWord as jest.Mock).mockResolvedValue('GRASS');
+    query.mockResolvedValueOnce([{ insertId: 5 }]).mockResolvedValueOnce([{}]);
+    const out = await saveMessage({ name: 'a', moderatorLevel: 0, isLoggedIn: true, isMobile: false, words: [], isBanned: false, xp: 0 }, {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: [['G', 'R', 'A', 'S', 'S']] },
+    } as unknown as Client.ChatMessage);
+    expect(query.mock.calls[1][1][1]).toBe('GRASS');
+    expect(getTodaysWord).toHaveBeenCalledTimes(1);
+    expect((out.content as Server.ChatMessage.SavedType).type).toBe(Server.MessageType.SCORE);
+  });
+
+  it('uses the custom solution when provided', async () => {
+    (getPlayerByName as jest.Mock).mockResolvedValue({ id: 1 });
+    query.mockResolvedValueOnce([{ insertId: 5 }]).mockResolvedValueOnce([{}]);
+    await saveMessage({ name: 'a', moderatorLevel: 0, isLoggedIn: true, isMobile: false, words: [], isBanned: false, xp: 0 }, {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { custom: 'BRICK', attempts: [['B', 'R', 'I', 'C', 'K']] },
+    } as unknown as Client.ChatMessage);
+    expect(query.mock.calls[1][1][1]).toBe('BRICK');
+    expect(getTodaysWord).not.toHaveBeenCalled();
+  });
+});
+
+describe('toggleMessage', () => {
+  it('returns false when no message matches the id', async () => {
+    query.mockResolvedValueOnce([[]]);
+    const result = await toggleMessage(99, {
+      name: 'a',
+      moderatorLevel: 1,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('refuses self-undelete when moderatorLevel is below the recorded delete level', async () => {
+    query.mockResolvedValueOnce([[buildJoinRow({ ID: 1, Username: 'alice', Deleted: 2 })]]);
+    const result = await toggleMessage(1, {
+      name: 'alice',
+      moderatorLevel: 1,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('marks a non-deleted message as deleted and returns true', async () => {
+    query.mockResolvedValueOnce([[buildJoinRow({ Deleted: 0 })]]).mockResolvedValueOnce([{ affectedRows: 1 }]);
+    const result = await toggleMessage(1, {
+      name: 'mod',
+      moderatorLevel: 2,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    });
+    expect(result).toBe(true);
+    expect(query.mock.calls[1][1]).toEqual([2, 1]);
+  });
+
+  it('un-deletes a previously deleted message', async () => {
+    query.mockResolvedValueOnce([[buildJoinRow({ Deleted: 1 })]]).mockResolvedValueOnce([{ affectedRows: 1 }]);
+    await toggleMessage(1, {
+      name: 'mod',
+      moderatorLevel: 2,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    });
+    expect(query.mock.calls[1][1]).toEqual([0, 1]);
+  });
+});

--- a/back/src/repositories/playerRepository.test.ts
+++ b/back/src/repositories/playerRepository.test.ts
@@ -1,0 +1,104 @@
+jest.mock('./pool.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+jest.mock('bcrypt', () => ({
+  __esModule: true,
+  default: {
+    hash: jest.fn(async () => 'hashed'),
+    compare: jest.fn(),
+  },
+}));
+
+import bcrypt from 'bcrypt';
+import pool from './pool.js';
+import { getPlayerByName, getPlayerBySessionHash, loginPlayer, registerPlayer, storeSessionHash } from './playerRepository.js';
+
+const query = pool.query as unknown as jest.Mock;
+
+const buildRow = (
+  overrides: Partial<{
+    ID: number;
+    Username: string;
+    Password: string;
+    SessionHash: string | null;
+    RegistrationDate: string;
+    IsAdmin: number;
+    IsBanned: number;
+  }> = {},
+) => ({
+  ID: 1,
+  Username: 'alice',
+  Password: 'pwhash',
+  SessionHash: null,
+  RegistrationDate: '2024-01-01',
+  IsAdmin: 0,
+  IsBanned: 0,
+  ...overrides,
+});
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('getPlayerBySessionHash', () => {
+  it('maps the row when found', async () => {
+    query.mockResolvedValueOnce([[buildRow({ SessionHash: 'h' })]]);
+    const player = await getPlayerBySessionHash('h');
+    expect(player).toMatchObject({ id: 1, username: 'alice', sessionHash: 'h' });
+  });
+
+  it('returns undefined when no row matches', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getPlayerBySessionHash('h')).toBeUndefined();
+  });
+});
+
+describe('getPlayerByName', () => {
+  it('returns the mapped player', async () => {
+    query.mockResolvedValueOnce([[buildRow()]]);
+    expect((await getPlayerByName('alice'))?.username).toBe('alice');
+  });
+});
+
+describe('registerPlayer', () => {
+  it('throws when the username is already taken', async () => {
+    query.mockResolvedValueOnce([[buildRow()]]);
+    await expect(registerPlayer('alice', 'pw')).rejects.toThrow('Oups, pseudo déjà pris.');
+  });
+
+  it('inserts a new player when the username is available', async () => {
+    query.mockResolvedValueOnce([[]]).mockResolvedValueOnce([{}]);
+    await registerPlayer('newcomer', 'pw');
+    expect(bcrypt.hash).toHaveBeenCalledWith('pw', 10);
+    expect(query).toHaveBeenLastCalledWith('INSERT INTO Player (Username, Password) VALUES (?, ?)', ['newcomer', 'hashed']);
+  });
+});
+
+describe('loginPlayer', () => {
+  it('throws when the user does not exist', async () => {
+    query.mockResolvedValueOnce([[]]);
+    await expect(loginPlayer('nope', 'pw')).rejects.toThrow('Utilisateur inconnu au bataillon...');
+  });
+
+  it('throws when the password does not match', async () => {
+    query.mockResolvedValueOnce([[buildRow()]]);
+    (bcrypt.compare as jest.Mock).mockResolvedValueOnce(false);
+    await expect(loginPlayer('alice', 'pw')).rejects.toThrow('Mot de passe invalide !');
+  });
+
+  it('returns the mapped player when login succeeds', async () => {
+    query.mockResolvedValueOnce([[buildRow({ Username: 'alice' })]]);
+    (bcrypt.compare as jest.Mock).mockResolvedValueOnce(true);
+    expect((await loginPlayer('alice', 'pw')).username).toBe('alice');
+  });
+});
+
+describe('storeSessionHash', () => {
+  it('runs an UPDATE Player query', async () => {
+    query.mockResolvedValueOnce([{}]);
+    await storeSessionHash(7, 'newhash');
+    expect(query).toHaveBeenCalledWith('UPDATE Player SET SessionHash = ? WHERE ID = ?', ['newhash', 7]);
+  });
+});

--- a/back/src/repositories/scoreRepository.test.ts
+++ b/back/src/repositories/scoreRepository.test.ts
@@ -1,0 +1,43 @@
+jest.mock('./pool.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import pool from './pool.js';
+import { getDailyScore, getScoreDistribution } from './scoreRepository.js';
+
+const query = pool.query as unknown as jest.Mock;
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('getScoreDistribution', () => {
+  it('counts attempts grouped by attempt count', async () => {
+    query.mockResolvedValueOnce([
+      [
+        { Attempts: JSON.stringify([['G'], ['G']]) },
+        { Attempts: JSON.stringify([['G'], ['G'], ['G']]) },
+        { Attempts: JSON.stringify([['G'], ['G']]) },
+      ],
+    ]);
+    expect(await getScoreDistribution('alice')).toEqual({ 2: 2, 3: 1 });
+  });
+
+  it('returns an empty object when no scores exist', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getScoreDistribution('alice')).toEqual({});
+  });
+});
+
+describe('getDailyScore', () => {
+  it('returns the parsed attempts when present', async () => {
+    query.mockResolvedValueOnce([[{ Attempts: JSON.stringify([['G', 'R', 'A', 'S', 'S']]) }]]);
+    expect(await getDailyScore('alice')).toEqual([['G', 'R', 'A', 'S', 'S']]);
+  });
+
+  it('returns an empty list when nothing was found', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getDailyScore('alice')).toEqual([]);
+  });
+});

--- a/back/src/repositories/tryRepository.test.ts
+++ b/back/src/repositories/tryRepository.test.ts
@@ -1,0 +1,60 @@
+jest.mock('./pool.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import pool from './pool.js';
+import { getOrCreateTry, getTodaysTriesForPlayer, updateTry } from './tryRepository.js';
+
+const query = pool.query as unknown as jest.Mock;
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('getTodaysTriesForPlayer', () => {
+  it('returns an empty list when no row matches', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getTodaysTriesForPlayer('alice')).toEqual([]);
+  });
+
+  it('joins each attempt array into a string', async () => {
+    query.mockResolvedValueOnce([
+      [
+        {
+          Attempts: JSON.stringify([
+            ['G', 'R', 'A', 'S', 'S'],
+            ['G', 'R', 'A', 'P', 'E'],
+          ]),
+        },
+      ],
+    ]);
+    expect(await getTodaysTriesForPlayer('alice')).toEqual(['GRASS', 'GRAPE']);
+  });
+});
+
+describe('getOrCreateTry', () => {
+  it('returns an empty record when the row does not exist', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getOrCreateTry(1, 1)).toEqual({ attempts: [], win: false });
+  });
+
+  it('parses the stored attempts and Win flag', async () => {
+    query.mockResolvedValueOnce([[{ Attempts: JSON.stringify([['G', 'R']]), Win: 1 }]]);
+    expect(await getOrCreateTry(1, 1)).toEqual({ attempts: [['G', 'R']], win: true });
+  });
+
+  it('defaults Win to false when null/0', async () => {
+    query.mockResolvedValueOnce([[{ Attempts: null, Win: 0 }]]);
+    expect(await getOrCreateTry(1, 1)).toEqual({ attempts: [], win: false });
+  });
+});
+
+describe('updateTry', () => {
+  it('runs an INSERT ... ON DUPLICATE KEY UPDATE with serialized attempts', async () => {
+    query.mockResolvedValueOnce([{}]);
+    await updateTry(1, 2, [['G', 'R', 'A', 'S', 'S']], true);
+    expect(query.mock.calls[0][0]).toMatch(/INSERT INTO Try/);
+    expect(query.mock.calls[0][1]).toEqual([1, 2, JSON.stringify([['G', 'R', 'A', 'S', 'S']]), true, 1]);
+  });
+});

--- a/back/src/repositories/wordRepository.test.ts
+++ b/back/src/repositories/wordRepository.test.ts
@@ -1,0 +1,77 @@
+jest.mock('./pool.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import pool from './pool.js';
+import { getOrCreateTodaysWord, getTodaysWord, getTodaysWordAndHistoryId, getValidWords } from './wordRepository.js';
+
+const query = pool.query as unknown as jest.Mock;
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('getTodaysWord', () => {
+  it('returns the first MotMinecraft when present', async () => {
+    query.mockResolvedValueOnce([[{ MotMinecraft: 'PIOCHE' }]]);
+    expect(await getTodaysWord()).toBe('PIOCHE');
+  });
+
+  it('returns null when no row matches today', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getTodaysWord()).toBeNull();
+  });
+});
+
+describe('getOrCreateTodaysWord', () => {
+  it('returns the existing word when one is already assigned for today', async () => {
+    query.mockResolvedValueOnce([[{ MotMinecraft: 'EXISTING' }]]);
+    expect(await getOrCreateTodaysWord()).toBe('EXISTING');
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when no word exists in the rotation pool', async () => {
+    query.mockResolvedValueOnce([[]]).mockResolvedValueOnce([[]]);
+    await expect(getOrCreateTodaysWord()).rejects.toThrow('No words available in MotMinecraft');
+  });
+
+  it('inserts a new entry and bumps the rotation when none exists for today', async () => {
+    query
+      .mockResolvedValueOnce([[]])
+      .mockResolvedValueOnce([[{ ID: 42, MotMinecraft: 'NEW' }]])
+      .mockResolvedValueOnce([{}])
+      .mockResolvedValueOnce([{}]);
+    expect(await getOrCreateTodaysWord()).toBe('NEW');
+    expect(query.mock.calls[2][0]).toMatch(/INSERT INTO WordHistory/);
+    expect(query.mock.calls[2][1]).toEqual([42]);
+    expect(query.mock.calls[3][0]).toMatch(/UPDATE MotMinecraft/);
+    expect(query.mock.calls[3][1]).toEqual([42]);
+  });
+});
+
+describe('getValidWords', () => {
+  it('returns the union of valid words for the right pattern', async () => {
+    query.mockResolvedValueOnce([[{ MotValide: 'GRASS' }, { MotValide: 'GRAPE' }]]);
+    const words = await getValidWords('GLASS');
+    expect(words).toEqual(['GRASS', 'GRAPE']);
+    expect(query.mock.calls[0][1]).toEqual(['G____', 'G____']);
+  });
+
+  it('returns an empty list when nothing matches', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getValidWords('GRASS')).toEqual([]);
+  });
+});
+
+describe('getTodaysWordAndHistoryId', () => {
+  it('returns the uppercased word and word history id', async () => {
+    query.mockResolvedValueOnce([[{ WordHistoryID: 7, MotMinecraft: 'pioche' }]]);
+    expect(await getTodaysWordAndHistoryId()).toEqual({ wordHistoryId: 7, todaysWord: 'PIOCHE' });
+  });
+
+  it('throws when no row is returned', async () => {
+    query.mockResolvedValueOnce([[]]);
+    await expect(getTodaysWordAndHistoryId()).rejects.toThrow('Mot du jour introuvable.');
+  });
+});

--- a/back/src/repositories/xpRepository.test.ts
+++ b/back/src/repositories/xpRepository.test.ts
@@ -1,0 +1,30 @@
+jest.mock('./pool.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import pool from './pool.js';
+import { getPlayerXp } from './xpRepository.js';
+
+const query = pool.query as unknown as jest.Mock;
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('getPlayerXp', () => {
+  it('returns the XP value reported by the query', async () => {
+    query.mockResolvedValueOnce([[{ XP: 123 }]]);
+    expect(await getPlayerXp('alice')).toBe(123);
+  });
+
+  it('returns 0 when no row is returned', async () => {
+    query.mockResolvedValueOnce([[]]);
+    expect(await getPlayerXp('alice')).toBe(0);
+  });
+
+  it('returns 0 when XP is null', async () => {
+    query.mockResolvedValueOnce([[{ XP: null }]]);
+    expect(await getPlayerXp('alice')).toBe(0);
+  });
+});

--- a/back/src/state/eventBus.test.ts
+++ b/back/src/state/eventBus.test.ts
@@ -1,0 +1,31 @@
+import { publish, subscribe } from './eventBus.js';
+
+describe('eventBus', () => {
+  it('invokes subscribers when an event is published', () => {
+    const cb = jest.fn();
+    subscribe('eventBus.test.basic', cb);
+    publish('eventBus.test.basic');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards arguments to subscribers', () => {
+    const cb = jest.fn();
+    subscribe('eventBus.test.args', cb);
+    publish('eventBus.test.args', 1, 'two', { three: 3 });
+    expect(cb).toHaveBeenCalledWith(1, 'two', { three: 3 });
+  });
+
+  it('invokes every subscriber registered for an event', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    subscribe('eventBus.test.multi', a);
+    subscribe('eventBus.test.multi', b);
+    publish('eventBus.test.multi');
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when publishing an event with no subscribers', () => {
+    expect(() => publish('eventBus.test.nobody')).not.toThrow();
+  });
+});

--- a/back/src/state/store.test.ts
+++ b/back/src/state/store.test.ts
@@ -1,0 +1,51 @@
+import store from './store.js';
+import FullUser from '../models/FullUser.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (id: string, name = 'alice') =>
+  new FullUser(
+    id,
+    {
+      name,
+      moderatorLevel: 0,
+      isLoggedIn: false,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+describe('store', () => {
+  beforeEach(() => {
+    store.setState({ users: {} });
+  });
+
+  it('starts with an empty users map after reset', () => {
+    expect(store.getState().users).toEqual({});
+  });
+
+  it('merges partial state via setState', () => {
+    const user = buildUser('id-1');
+    store.setState({ users: { 'id-1': user } });
+    expect(store.getState().users['id-1']).toBe(user);
+  });
+
+  it('notifies subscribers when state changes', () => {
+    const cb = jest.fn();
+    store.subscribe(cb);
+    store.setState({ users: {} });
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('passes the new state to subscribers', () => {
+    const cb = jest.fn();
+    store.subscribe(cb);
+    const user = buildUser('id-2');
+    store.setState({ users: { 'id-2': user } });
+    expect(cb).toHaveBeenCalledWith(expect.objectContaining({ users: { 'id-2': user } }));
+  });
+});

--- a/back/src/utils/crypto.test.ts
+++ b/back/src/utils/crypto.test.ts
@@ -1,0 +1,41 @@
+import bcrypt from 'bcrypt';
+import { generateRandomHash, passwordInHashArray } from './crypto.js';
+
+describe('generateRandomHash', () => {
+  it('returns a 32-character hex string (16 random bytes)', () => {
+    const hash = generateRandomHash();
+    expect(hash).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('returns a different value on consecutive calls', () => {
+    const hashes = new Set([generateRandomHash(), generateRandomHash(), generateRandomHash(), generateRandomHash()]);
+    expect(hashes.size).toBe(4);
+  });
+});
+
+describe('passwordInHashArray', () => {
+  const password = 'secret-password';
+  let validHash: string;
+
+  beforeAll(() => {
+    validHash = bcrypt.hashSync(password, 4);
+  });
+
+  it('returns true when password matches one of the hashes', () => {
+    expect(passwordInHashArray(password, [validHash])).toBe(true);
+  });
+
+  it('returns true when password matches any of multiple hashes', () => {
+    const otherHash = bcrypt.hashSync('different', 4);
+    expect(passwordInHashArray(password, [otherHash, validHash])).toBe(true);
+  });
+
+  it('returns false when password matches none of the hashes', () => {
+    const otherHash = bcrypt.hashSync('different', 4);
+    expect(passwordInHashArray('wrong', [otherHash, validHash])).toBe(false);
+  });
+
+  it('returns false on empty hash list', () => {
+    expect(passwordInHashArray(password, [])).toBe(false);
+  });
+});

--- a/back/src/utils/mappers.test.ts
+++ b/back/src/utils/mappers.test.ts
@@ -1,0 +1,188 @@
+import { Server } from '@surtom/interfaces';
+import store from '../state/store.js';
+import FullUser from '../models/FullUser.js';
+import {
+  mapDatabaseMessageToMemoryMessage,
+  mapDatabaseTypeToMemoryType,
+  mapDatabaseUserToMemoryUser,
+  mapFullUserToUser,
+  mapScoreMessageToMemoryMessage,
+  mapUserMessageToMemoryMessage,
+} from './mappers.js';
+
+const fakeWs = {} as never;
+
+const buildPrivateUser = (overrides: Partial<Server.PrivateUser> = {}): Server.PrivateUser => ({
+  name: 'alice',
+  moderatorLevel: 0,
+  isLoggedIn: true,
+  isMobile: false,
+  words: [],
+  isBanned: false,
+  xp: 42,
+  ...overrides,
+});
+
+describe('mapFullUserToUser', () => {
+  it('exposes only the public-safe fields', () => {
+    const user = new FullUser('id-1', buildPrivateUser({ name: 'bob', moderatorLevel: 2, xp: 100 }), fakeWs, '127.0.0.1');
+    expect(mapFullUserToUser(user)).toEqual({
+      name: 'bob',
+      moderatorLevel: 2,
+      isMobile: false,
+      isLoggedIn: true,
+      xp: 100,
+    });
+  });
+
+  it('does not leak isBanned, words, or ip', () => {
+    const user = new FullUser('id-1', buildPrivateUser({ isBanned: true, words: ['secret'] }), fakeWs, '10.0.0.1');
+    const mapped = mapFullUserToUser(user) as unknown as Record<string, unknown>;
+    expect(mapped.isBanned).toBeUndefined();
+    expect(mapped.words).toBeUndefined();
+    expect(mapped.ip).toBeUndefined();
+  });
+});
+
+describe('mapDatabaseUserToMemoryUser', () => {
+  beforeEach(() => {
+    store.setState({ users: {} });
+  });
+
+  it('returns null on null input', () => {
+    expect(mapDatabaseUserToMemoryUser(null)).toBeNull();
+  });
+
+  it('returns the matching FullUser from the store by Pseudo', () => {
+    const user = new FullUser('id-1', buildPrivateUser({ name: 'alice' }), fakeWs, '127.0.0.1');
+    store.setState({ users: { [user.id]: user } });
+    expect(mapDatabaseUserToMemoryUser({ Pseudo: 'alice' })).toBe(user);
+  });
+
+  it('returns null when no FullUser matches', () => {
+    expect(mapDatabaseUserToMemoryUser({ Pseudo: 'unknown' })).toBeNull();
+  });
+});
+
+describe('mapUserMessageToMemoryMessage', () => {
+  it('maps every field, including reply id stringification', () => {
+    expect(
+      mapUserMessageToMemoryMessage({
+        ID: 1,
+        Pseudo: 'alice',
+        Moderator: 1,
+        Texte: 'hello',
+        Date: '2024-01-01T00:00:00.000Z',
+        ImageData: 'base64',
+        Reply: 7,
+      }),
+    ).toEqual({
+      id: '1',
+      user: { name: 'alice', moderatorLevel: 1 },
+      text: 'hello',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      imageData: 'base64',
+      replyId: '7',
+      deleted: 0,
+    });
+  });
+
+  it('handles missing optional fields gracefully', () => {
+    expect(
+      mapUserMessageToMemoryMessage({
+        Pseudo: '',
+        Moderator: 0,
+        Date: '',
+      }),
+    ).toEqual({
+      id: '',
+      user: { name: '', moderatorLevel: 0 },
+      text: '',
+      timestamp: '',
+      imageData: undefined,
+      replyId: undefined,
+      deleted: 0,
+    });
+  });
+
+  it('skips imageData when not a string', () => {
+    expect(
+      mapUserMessageToMemoryMessage({
+        Pseudo: 'a',
+        Moderator: 0,
+        Date: 'd',
+        ImageData: undefined,
+      }).imageData,
+    ).toBeUndefined();
+  });
+});
+
+describe('mapScoreMessageToMemoryMessage', () => {
+  it('parses Mots as JSON', () => {
+    expect(
+      mapScoreMessageToMemoryMessage({
+        ID: 5,
+        Pseudo: 'alice',
+        Moderator: 0,
+        Date: '2024-01-01',
+        Answer: 'GRASS',
+        Mots: '[["G","R","A","S","S"]]',
+      }),
+    ).toEqual({
+      id: '5',
+      user: { name: 'alice', moderatorLevel: 0 },
+      answer: 'GRASS',
+      attempts: [['G', 'R', 'A', 'S', 'S']],
+      timestamp: '2024-01-01',
+      deleted: 0,
+    });
+  });
+
+  it('falls back to an empty attempts list when Mots is missing', () => {
+    const out = mapScoreMessageToMemoryMessage({ Pseudo: '', Moderator: 0, Date: '' });
+    expect(out.attempts).toEqual([]);
+  });
+});
+
+describe('mapDatabaseTypeToMemoryType', () => {
+  it('maps each known type', () => {
+    expect(mapDatabaseTypeToMemoryType('score')).toBe(Server.MessageType.SCORE);
+    expect(mapDatabaseTypeToMemoryType('enhanced')).toBe(Server.MessageType.ENHANCED);
+    expect(mapDatabaseTypeToMemoryType('message')).toBe(Server.MessageType.TEXT);
+  });
+
+  it('returns undefined for missing type', () => {
+    expect(mapDatabaseTypeToMemoryType(undefined)).toBeUndefined();
+  });
+});
+
+describe('mapDatabaseMessageToMemoryMessage', () => {
+  it('returns undefined when Type is missing', () => {
+    expect(mapDatabaseMessageToMemoryMessage({ Pseudo: '', Moderator: 0, Date: '' })).toBeUndefined();
+  });
+
+  it('routes message/enhanced to the user message mapper', () => {
+    const out = mapDatabaseMessageToMemoryMessage({
+      ID: 1,
+      Pseudo: 'a',
+      Moderator: 0,
+      Date: 'd',
+      Texte: 'hi',
+      Type: 'message',
+    });
+    expect(out).toMatchObject({ text: 'hi' });
+  });
+
+  it('routes score to the score mapper', () => {
+    const out = mapDatabaseMessageToMemoryMessage({
+      ID: 1,
+      Pseudo: 'a',
+      Moderator: 0,
+      Date: 'd',
+      Answer: 'GRASS',
+      Mots: '[["G"]]',
+      Type: 'score',
+    });
+    expect(out).toMatchObject({ answer: 'GRASS' });
+  });
+});

--- a/back/src/utils/randomName.test.ts
+++ b/back/src/utils/randomName.test.ts
@@ -1,0 +1,37 @@
+import { funnyNames } from '../data/funnyNames.js';
+import { getRandomFunnyName, isFunnyName } from './randomName.js';
+
+describe('getRandomFunnyName', () => {
+  it('returns a name from the funnyNames list', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(funnyNames).toContain(getRandomFunnyName());
+    }
+  });
+
+  it('uses Math.random to index into the list', () => {
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    expect(getRandomFunnyName()).toBe(funnyNames[0]);
+    spy.mockReturnValue(0.999999);
+    expect(getRandomFunnyName()).toBe(funnyNames[funnyNames.length - 1]);
+    spy.mockRestore();
+  });
+});
+
+describe('isFunnyName', () => {
+  it('returns true for any name in the list', () => {
+    funnyNames.forEach((name) => {
+      expect(isFunnyName(name)).toBe(true);
+    });
+  });
+
+  it('returns false for unknown names', () => {
+    expect(isFunnyName('not-a-funny-name')).toBe(false);
+    expect(isFunnyName('')).toBe(false);
+    expect(isFunnyName('Surtomien_X')).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(isFunnyName('surtomien')).toBe(false);
+    expect(isFunnyName('Surtomien')).toBe(true);
+  });
+});

--- a/back/src/utils/score.test.ts
+++ b/back/src/utils/score.test.ts
@@ -1,0 +1,34 @@
+import { isScoreContentCoherent } from './score.js';
+
+const make = (attempts: string[][]) => ({ attempts });
+
+describe('isScoreContentCoherent', () => {
+  it('rejects empty attempts list', () => {
+    expect(isScoreContentCoherent(make([]))).toBe(false);
+  });
+
+  it('accepts a single attempt', () => {
+    expect(isScoreContentCoherent(make([['G', 'R', 'A', 'S', 'S']]))).toBe(true);
+  });
+
+  it('accepts up to 6 attempts of equal length', () => {
+    const attempts = Array.from({ length: 6 }, () => ['G', 'R', 'A', 'S', 'S']);
+    expect(isScoreContentCoherent(make(attempts))).toBe(true);
+  });
+
+  it('rejects more than 6 attempts', () => {
+    const attempts = Array.from({ length: 7 }, () => ['G', 'R', 'A', 'S', 'S']);
+    expect(isScoreContentCoherent(make(attempts))).toBe(false);
+  });
+
+  it('rejects attempts of varying length', () => {
+    expect(
+      isScoreContentCoherent(
+        make([
+          ['A', 'B', 'C'],
+          ['A', 'B'],
+        ]),
+      ),
+    ).toBe(false);
+  });
+});

--- a/back/src/utils/validate.test.ts
+++ b/back/src/utils/validate.test.ts
@@ -1,0 +1,58 @@
+import { isJson, validateText, validateUsername } from './validate.js';
+
+describe('validateUsername', () => {
+  it.each([
+    ['simple', 'alice', true],
+    ['with digits', 'bob42', true],
+    ['underscore', 'foo_bar', true],
+    ['hyphen', 'foo-bar', true],
+    ['single char', 'a', true],
+    ['16 chars max', 'a'.repeat(16), true],
+  ])('accepts %s', (_label, value, expected) => {
+    expect(validateUsername(value)).toBe(expected);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['too long', 'a'.repeat(17)],
+    ['space', 'foo bar'],
+    ['special chars', 'foo!'],
+    ['unicode', 'aliçe'],
+    ['dot', 'foo.bar'],
+    ['newline', 'foo\nbar'],
+  ])('rejects %s', (_label, value) => {
+    expect(validateUsername(value)).toBe(false);
+  });
+});
+
+describe('validateText', () => {
+  it('accepts a single character', () => {
+    expect(validateText('a')).toBe(true);
+  });
+
+  it('accepts the maximum length (256 chars)', () => {
+    expect(validateText('a'.repeat(256))).toBe(true);
+  });
+
+  it('rejects an empty string', () => {
+    expect(validateText('')).toBe(false);
+  });
+
+  it('rejects strings longer than 256 chars', () => {
+    expect(validateText('a'.repeat(257))).toBe(false);
+  });
+
+  it('rejects strings containing a newline (single-line regex)', () => {
+    expect(validateText('hello\nworld')).toBe(false);
+  });
+});
+
+describe('isJson', () => {
+  it.each([['"a string"'], ['{}'], ['[]'], ['{"a":1}'], ['null'], ['42'], ['true']])('accepts valid JSON %s', (input) => {
+    expect(isJson(input)).toBe(true);
+  });
+
+  it.each([[''], ['{'], ['{a:1}'], ['undefined'], ['function(){}']])('rejects invalid JSON %s', (input) => {
+    expect(isJson(input)).toBe(false);
+  });
+});

--- a/back/src/ws/broadcast.test.ts
+++ b/back/src/ws/broadcast.test.ts
@@ -1,0 +1,61 @@
+import WS, { WebSocketServer } from 'ws';
+import { Server } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+import { broadcastAll, broadcastAllButSelf, setWebSocketServer } from './broadcast.js';
+
+const makeWs = (readyState: number = WS.OPEN) => {
+  const send = jest.fn();
+  return { send, readyState } as unknown as WS & { send: jest.Mock };
+};
+
+const validMessage: Server.Message = {
+  type: Server.MessageType.LOG,
+  content: 'hi',
+};
+
+const setupServer = (clients: WS[]) => {
+  setWebSocketServer({ clients: new Set(clients) } as unknown as WebSocketServer);
+};
+
+describe('broadcastAll', () => {
+  it('sends the message to every client connected to the server', () => {
+    const a = makeWs();
+    const b = makeWs();
+    setupServer([a, b]);
+    broadcastAll(validMessage);
+    expect(a.send).toHaveBeenCalledWith(JSON.stringify(validMessage));
+    expect(b.send).toHaveBeenCalledWith(JSON.stringify(validMessage));
+  });
+});
+
+describe('broadcastAllButSelf', () => {
+  it('skips the sender connection and sends to everyone else', () => {
+    const own = makeWs();
+    const other = makeWs();
+    setupServer([own, other]);
+    const user = new FullUser(
+      'id-1',
+      {
+        name: 'me',
+        moderatorLevel: 0,
+        isLoggedIn: false,
+        isMobile: false,
+        words: [],
+        isBanned: false,
+        xp: 0,
+      },
+      own,
+      'ip',
+    );
+    broadcastAllButSelf(user, validMessage);
+    expect(own.send).not.toHaveBeenCalled();
+    expect(other.send).toHaveBeenCalled();
+  });
+});
+
+describe('without a configured server', () => {
+  it('throws when broadcasting before setWebSocketServer is called', () => {
+    setWebSocketServer(undefined as unknown as WebSocketServer);
+    expect(() => broadcastAll(validMessage)).toThrow('WebSocketServer not initialized');
+  });
+});

--- a/back/src/ws/cookies.test.ts
+++ b/back/src/ws/cookies.test.ts
@@ -1,0 +1,31 @@
+import { parseCookies } from './cookies.js';
+
+describe('parseCookies', () => {
+  it('returns an empty object when the header is undefined', () => {
+    expect(parseCookies(undefined)).toEqual({});
+  });
+
+  it('parses a single cookie', () => {
+    expect(parseCookies('foo=bar')).toEqual({ foo: 'bar' });
+  });
+
+  it('parses multiple cookies separated by ;', () => {
+    expect(parseCookies('a=1; b=2; c=3')).toEqual({ a: '1', b: '2', c: '3' });
+  });
+
+  it('trims whitespace around keys and values', () => {
+    expect(parseCookies('  foo  =  bar  ;  baz=qux')).toEqual({ foo: 'bar', baz: 'qux' });
+  });
+
+  it('handles cookies without a value', () => {
+    expect(parseCookies('foo=; bar=baz')).toEqual({ foo: '', bar: 'baz' });
+  });
+
+  it('uses the value before the first = (browser-style)', () => {
+    expect(parseCookies('token=abc=def').token).toBe('abc');
+  });
+
+  it('skips fragments without a key', () => {
+    expect(parseCookies(';foo=bar')).toEqual({ foo: 'bar' });
+  });
+});

--- a/back/src/ws/customType.test.ts
+++ b/back/src/ws/customType.test.ts
@@ -1,0 +1,82 @@
+import WS from 'ws';
+import store from '../state/store.js';
+import FullUser from '../models/FullUser.js';
+import { dispatchCustomMessage } from './customType.js';
+
+const makeWs = (readyState: number = WS.OPEN) => {
+  const send = jest.fn();
+  return { send, readyState } as unknown as WS & { send: jest.Mock };
+};
+
+const buildPrivateUser = (name: string) => ({
+  name,
+  moderatorLevel: 0,
+  isLoggedIn: false,
+  isMobile: false,
+  words: [],
+  isBanned: false,
+  xp: 0,
+});
+
+describe('dispatchCustomMessage', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    store.setState({ users: {} });
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('forwards the payload to every user listening for that type', () => {
+    const wsA = makeWs();
+    const wsB = makeWs();
+    const sender = new FullUser('id-0', buildPrivateUser('sender'), makeWs(), 'ip');
+
+    const a = new FullUser('id-1', buildPrivateUser('alice'), wsA, 'ip');
+    const b = new FullUser('id-2', buildPrivateUser('bob'), wsB, 'ip');
+    a.listeningTypes.push('customType');
+    b.listeningTypes.push('customType');
+
+    store.setState({ users: { 'id-0': sender, 'id-1': a, 'id-2': b } });
+
+    dispatchCustomMessage(sender, 'customType', { foo: 'bar' });
+
+    const expected = JSON.stringify({ type: 'customType', content: { foo: 'bar' } });
+    expect(wsA.send).toHaveBeenCalledWith(expected);
+    expect(wsB.send).toHaveBeenCalledWith(expected);
+  });
+
+  it('does not send to users that are not listening for the type', () => {
+    const ws = makeWs();
+    const sender = new FullUser('id-0', buildPrivateUser('sender'), makeWs(), 'ip');
+    const listener = new FullUser('id-1', buildPrivateUser('listener'), ws, 'ip');
+    listener.listeningTypes.push('otherType');
+    store.setState({ users: { 'id-0': sender, 'id-1': listener } });
+
+    dispatchCustomMessage(sender, 'customType', {});
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('skips listeners whose connection is not OPEN', () => {
+    const closed = makeWs(WS.CLOSED);
+    const sender = new FullUser('id-0', buildPrivateUser('sender'), makeWs(), 'ip');
+    const listener = new FullUser('id-1', buildPrivateUser('listener'), closed, 'ip');
+    listener.listeningTypes.push('customType');
+    store.setState({ users: { 'id-0': sender, 'id-1': listener } });
+
+    dispatchCustomMessage(sender, 'customType', {});
+
+    expect(closed.send).not.toHaveBeenCalled();
+  });
+
+  it('logs an "empty" message when there are no listeners for the type', () => {
+    const sender = new FullUser('id-0', buildPrivateUser('sender'), makeWs(), 'ip');
+    store.setState({ users: { 'id-0': sender } });
+    dispatchCustomMessage(sender, 'unknown', {});
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Wrong message type or empty (unknown)'));
+  });
+});

--- a/back/src/ws/dispatcher.test.ts
+++ b/back/src/ws/dispatcher.test.ts
@@ -1,0 +1,149 @@
+import { Client } from '@surtom/interfaces';
+import FullUser from '../models/FullUser.js';
+
+jest.mock('../commands/index.js', () => ({ __esModule: true, handleCommand: jest.fn() }));
+jest.mock('../handlers/chatHandler.js', () => ({ __esModule: true, handleChatMessage: jest.fn() }));
+jest.mock('../handlers/deleteHandler.js', () => ({ __esModule: true, handleDeleteMessage: jest.fn() }));
+jest.mock('../handlers/tryHandler.js', () => ({ __esModule: true, handleTryMessage: jest.fn() }));
+jest.mock('../handlers/cursorHandler.js', () => ({ __esModule: true, handleCursorPosition: jest.fn() }));
+jest.mock('../handlers/typingHandler.js', () => ({ __esModule: true, handleIsTyping: jest.fn() }));
+jest.mock('./customType.js', () => ({ __esModule: true, dispatchCustomMessage: jest.fn() }));
+
+import { handleCommand } from '../commands/index.js';
+import { handleChatMessage } from '../handlers/chatHandler.js';
+import { handleDeleteMessage } from '../handlers/deleteHandler.js';
+import { handleTryMessage } from '../handlers/tryHandler.js';
+import { handleCursorPosition } from '../handlers/cursorHandler.js';
+import { handleIsTyping } from '../handlers/typingHandler.js';
+import { dispatchCustomMessage } from './customType.js';
+import { handleMessage, shouldLogMessage } from './dispatcher.js';
+import { RATE_LIMIT_FREE_MESSAGES, COOLDOWN_INITIAL_SECONDS } from '../config/constants.js';
+
+const fakeWs = {} as never;
+
+const buildUser = (moderatorLevel = 0) =>
+  new FullUser(
+    'id-1',
+    {
+      name: 'alice',
+      moderatorLevel,
+      isLoggedIn: true,
+      isMobile: false,
+      words: [],
+      isBanned: false,
+      xp: 0,
+    },
+    fakeWs,
+    'ip',
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('shouldLogMessage', () => {
+  it('returns false for silent message types', () => {
+    expect(shouldLogMessage(Client.MessageType.PING)).toBe(false);
+    expect(shouldLogMessage(Client.MessageType.IS_TYPING)).toBe(false);
+    expect(shouldLogMessage(Client.MessageType.CURSOR_POSITION)).toBe(false);
+  });
+
+  it('returns true for any other type', () => {
+    expect(shouldLogMessage(Client.MessageType.CHAT_MESSAGE)).toBe(true);
+    expect(shouldLogMessage(Client.MessageType.TRY)).toBe(true);
+  });
+});
+
+describe('handleMessage routing', () => {
+  it('drops PINGs without dispatching', async () => {
+    await handleMessage(buildUser(), { type: Client.MessageType.PING });
+    expect(handleChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('routes a slash chat message to the command handler', async () => {
+    await handleMessage(buildUser(), { type: Client.MessageType.CHAT_MESSAGE, content: { text: '/help' } });
+    expect(handleCommand).toHaveBeenCalledWith(expect.any(Object), 'help');
+    expect(handleChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('routes a regular chat message to the chat handler', async () => {
+    const message = { type: Client.MessageType.CHAT_MESSAGE, content: { text: 'hello' } } as Client.ChatMessage;
+    await handleMessage(buildUser(), message);
+    expect(handleChatMessage).toHaveBeenCalledWith(expect.any(Object), message);
+  });
+
+  it('routes SCORE_TO_CHAT to the chat handler', async () => {
+    const message = {
+      type: Client.MessageType.SCORE_TO_CHAT,
+      content: { attempts: [['G', 'R', 'A', 'S', 'S']] },
+    } as unknown as Client.Message;
+    await handleMessage(buildUser(), message);
+    expect(handleChatMessage).toHaveBeenCalledWith(expect.any(Object), message);
+  });
+
+  it('routes DELETE_MESSAGE to the delete handler', async () => {
+    await handleMessage(buildUser(2), { type: Client.MessageType.DELETE_MESSAGE, content: 7 });
+    expect(handleDeleteMessage).toHaveBeenCalledWith(expect.any(Object), 7);
+  });
+
+  it('routes IS_TYPING to the typing handler without rate-limiting', async () => {
+    const user = buildUser();
+    user.messageCount = 9999;
+    await handleMessage(user, { type: Client.MessageType.IS_TYPING });
+    expect(handleIsTyping).toHaveBeenCalled();
+  });
+
+  it('routes TRY to the try handler', async () => {
+    await handleMessage(buildUser(), { type: Client.MessageType.TRY, content: 'GRASS' });
+    expect(handleTryMessage).toHaveBeenCalledWith(expect.any(Object), 'GRASS');
+  });
+
+  it('routes CURSOR_POSITION to the cursor handler', async () => {
+    await handleMessage(buildUser(), {
+      type: Client.MessageType.CURSOR_POSITION,
+      content: { cursor: { x: 1, y: 2 } },
+    } as Client.Message);
+    expect(handleCursorPosition).toHaveBeenCalledWith(expect.any(Object), { x: 1, y: 2 });
+  });
+
+  it('falls back to dispatchCustomMessage for unknown types', async () => {
+    await handleMessage(buildUser(), { type: 'custom', content: { hello: 'world' } } as unknown as Client.Message);
+    expect(dispatchCustomMessage).toHaveBeenCalledWith(expect.any(Object), 'custom', { hello: 'world' });
+  });
+});
+
+describe('rate limiting', () => {
+  it('does not rate-limit moderators', async () => {
+    const mod = buildUser(2);
+    for (let i = 0; i < RATE_LIMIT_FREE_MESSAGES + 5; i++) {
+      await handleMessage(mod, { type: Client.MessageType.CHAT_MESSAGE, content: { text: 'hi' } });
+    }
+    expect(handleChatMessage).toHaveBeenCalledTimes(RATE_LIMIT_FREE_MESSAGES + 5);
+  });
+
+  it('applies a cooldown to non-moderators after the free quota', async () => {
+    const user = buildUser();
+    const message = { type: Client.MessageType.CHAT_MESSAGE, content: { text: 'spam' } } as Client.ChatMessage;
+
+    for (let i = 0; i < RATE_LIMIT_FREE_MESSAGES; i++) {
+      await handleMessage(user, message);
+    }
+    const baseline = (handleChatMessage as jest.Mock).mock.calls.length;
+
+    user.lastMessageTimestamp = new Date().toISOString();
+    await handleMessage(user, message);
+    expect((handleChatMessage as jest.Mock).mock.calls.length).toBe(baseline);
+    expect(user.messageCooldown).toBe(COOLDOWN_INITIAL_SECONDS * user.cooldownMultiplier);
+  });
+
+  it('resets the cooldown to the initial value once enough time has elapsed', async () => {
+    const user = buildUser();
+    const message = { type: Client.MessageType.CHAT_MESSAGE, content: { text: 'hi' } } as Client.ChatMessage;
+    user.messageCount = RATE_LIMIT_FREE_MESSAGES + 1;
+    user.messageCooldown = COOLDOWN_INITIAL_SECONDS * 2;
+    user.lastMessageTimestamp = new Date(Date.now() - (user.messageCooldown * 1000 + 5000)).toISOString();
+    await handleMessage(user, message);
+    expect(handleChatMessage).toHaveBeenCalled();
+    expect(user.messageCooldown).toBe(COOLDOWN_INITIAL_SECONDS);
+  });
+});

--- a/back/src/ws/send.test.ts
+++ b/back/src/ws/send.test.ts
@@ -1,0 +1,87 @@
+import WS from 'ws';
+import { Server } from '@surtom/interfaces';
+import { sendError, sendSuccess, sendToAll, sendToUser } from './send.js';
+
+const makeWs = (readyState: number = WS.OPEN) => {
+  const send = jest.fn();
+  return { send, readyState } as unknown as WS & { send: jest.Mock };
+};
+
+const validMessage: Server.Message = {
+  type: Server.MessageType.LOG,
+  content: 'hello',
+};
+
+describe('sendToUser', () => {
+  it('sends a serialized payload when the connection is OPEN', () => {
+    const ws = makeWs(WS.OPEN);
+    sendToUser(ws, validMessage);
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify(validMessage));
+  });
+
+  it('does not send when the connection is not OPEN', () => {
+    const ws = makeWs(WS.CONNECTING);
+    sendToUser(ws, validMessage);
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('logs and skips when the message is invalid', () => {
+    const ws = makeWs(WS.OPEN);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    sendToUser(ws, { type: 'NOPE', content: null } as unknown as Server.Message);
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('sendToAll', () => {
+  it('sends to every OPEN client and skips others', () => {
+    const open = makeWs(WS.OPEN);
+    const closed = makeWs(WS.CLOSED);
+    const connecting = makeWs(WS.CONNECTING);
+    sendToAll(new Set([open, closed, connecting]), validMessage);
+    expect(open.send).toHaveBeenCalledWith(JSON.stringify(validMessage));
+    expect(closed.send).not.toHaveBeenCalled();
+    expect(connecting.send).not.toHaveBeenCalled();
+  });
+
+  it('serializes the payload only once for the broadcast', () => {
+    const a = makeWs(WS.OPEN);
+    const b = makeWs(WS.OPEN);
+    sendToAll(new Set([a, b]), validMessage);
+    expect(a.send).toHaveBeenCalledWith(expect.any(String));
+    expect(b.send).toHaveBeenCalledWith(expect.any(String));
+    expect(a.send.mock.calls[0][0]).toBe(b.send.mock.calls[0][0]);
+  });
+
+  it('logs and skips invalid messages', () => {
+    const ws = makeWs(WS.OPEN);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    sendToAll(new Set([ws]), { type: 'NOPE', content: null } as unknown as Server.Message);
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('sendError / sendSuccess', () => {
+  it('wraps an error text into a MESSAGE/ERROR envelope', () => {
+    const ws = makeWs(WS.OPEN);
+    sendError(ws, 'oops');
+    const payload = JSON.parse(ws.send.mock.calls[0][0]);
+    expect(payload.type).toBe(Server.MessageType.MESSAGE);
+    expect(payload.content.type).toBe(Server.MessageType.ERROR);
+    expect(payload.content.content.text).toBe('oops');
+    expect(typeof payload.content.content.timestamp).toBe('string');
+  });
+
+  it('wraps a success text into a MESSAGE/SUCCESS envelope', () => {
+    const ws = makeWs(WS.OPEN);
+    sendSuccess(ws, 'great');
+    const payload = JSON.parse(ws.send.mock.calls[0][0]);
+    expect(payload.type).toBe(Server.MessageType.MESSAGE);
+    expect(payload.content.type).toBe(Server.MessageType.SUCCESS);
+    expect(payload.content.content.text).toBe('great');
+  });
+});

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -10,5 +10,5 @@
     "moduleResolution": "node"
   },
   "references": [{ "path": "../interfaces" }],
-  "exclude": ["node_modules", "*.test.ts", "*.spec.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,12 +34,176 @@
         "ws": "^8.17.0"
       },
       "devDependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/preset-env": "^7.29.2",
         "@types/jest": "^29.5.14",
+        "babel-jest": "^30.3.0",
         "jest": "^29.7.0",
         "nodemon": "^3.1.10",
         "ts-jest": "^29.2.5",
         "tsc-watch": "^7.1.1",
         "tsx": "^4.19.3"
+      }
+    },
+    "back/node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "back/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "back/node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "back/node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "back/node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "back/node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "back/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "back/node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "back/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "front": {
@@ -151,11 +315,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -164,27 +328,27 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -201,12 +365,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -215,12 +379,24 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -228,6 +404,60 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "regexpu-core": "^6.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "debug": "^4.4.3",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.11"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -238,26 +468,39 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -266,10 +509,69 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
+    "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -298,30 +600,135 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "dev": true,
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -375,13 +782,28 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -546,6 +968,642 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/template": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
@@ -574,6 +1632,289 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.29.0",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -584,29 +1925,29 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -614,9 +1955,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -3551,6 +4892,45 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
@@ -3622,11 +5002,14 @@
       ]
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
-      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bcrypt": {
@@ -3707,9 +5090,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
-      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3725,11 +5108,11 @@
         }
       ],
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.19",
-        "caniuse-lite": "^1.0.30001751",
-        "electron-to-chromium": "^1.5.238",
-        "node-releases": "^2.0.26",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3819,9 +5202,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001751",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
-      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4169,6 +5552,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -5242,9 +6638,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.241",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.241.tgz",
-      "integrity": "sha512-ILMvKX/ZV5WIJzzdtuHg8xquk2y0BOGlFOxBVwTpbiXqWIH0hamG45ddU4R3PQ0gYu+xgo0vdHXHli9sHIGb4w=="
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -8657,6 +10053,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9032,9 +10434,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
-      "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA=="
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="
     },
     "node_modules/nodemon": {
       "version": "3.1.10",
@@ -9844,6 +11246,59 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+      "dev": true,
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+      "dev": true,
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.2",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.13.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "dev": true,
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -11424,6 +12879,46 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -11471,9 +12966,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

- ~250 specs across 40 sibling `*.test.ts` suites covering every refactored back module: utils, state, models, ws layer, handlers, command router/handlers and repositories.
- Repository and command tests use `jest.mock` to isolate the MySQL pool, `bcrypt`, the WebSocket layer and the event bus, so no DB or network is required to run the suite.
- Wires Jest to handle the workspace-linked ESM `@surtom/interfaces` dist via `babel-jest` for `.js` and `ts-jest` for `.ts` (CommonJS output).
- Tightens `back/tsconfig.json` exclude so test files no longer leak into the production build.

## Test plan

- [x] `cd back && npx jest` -> 250 / 250 passing.
- [x] `cd back && npx tsc --noEmit` clean.
- [x] `cd back && rm -rf dist && npx tsc` -> no `*.test.js` artifacts in `dist/`.

Rebased on top of #49 (`refactor/back-architecture`).