### PR TITLE
Remove super-admin moderator level and refactor type

### DIFF
--- a/back/src/commands/help/handler.ts
+++ b/back/src/commands/help/handler.ts
@@ -29,7 +29,7 @@ export function handleHelpCommand(user: FullUser, parts: string[]): void {
         text: JSON.stringify(formatted),
         timestamp: new Date().toISOString(),
         id: '-1',
-        user: { name: 'System', moderatorLevel: 2 },
+        user: { name: 'System', moderatorLevel: Server.ModeratorLevel.System },
         deleted: 0,
       },
     },

--- a/back/src/repositories/messageRepository.ts
+++ b/back/src/repositories/messageRepository.ts
@@ -95,7 +95,7 @@ export function getHelpMessage(): Server.ChatMessage.SavedType {
     type: Server.MessageType.ENHANCED,
     content: {
       id: '0',
-      user: { name: 'System', moderatorLevel: Server.ModeratorLevel.Operator },
+      user: { name: 'System', moderatorLevel: Server.ModeratorLevel.System },
       text: '[{"text":"Faites ","color":"LemonChiffon"},{"text":"/help","color":"DarkKhaki"},{"text":" pour plus d\'information","color":"LemonChiffon"}]',
       timestamp: new Date().toISOString(),
       deleted: 0,

--- a/back/src/repositories/messageRepository.ts
+++ b/back/src/repositories/messageRepository.ts
@@ -47,7 +47,7 @@ function mapMessage(row: MessageJoinRow): Server.ChatMessage.SavedType {
     id: row.ID.toString(),
     user: {
       name: row.Username,
-      moderatorLevel: row.IsAdmin ?? 0,
+      moderatorLevel: row.IsAdmin ?? Server.ModeratorLevel.Player,
     },
     timestamp: new Date(row.Timestamp).toISOString(),
     deleted: row.Deleted ?? 0,
@@ -95,7 +95,7 @@ export function getHelpMessage(): Server.ChatMessage.SavedType {
     type: Server.MessageType.ENHANCED,
     content: {
       id: '0',
-      user: { name: 'System', moderatorLevel: 2 },
+      user: { name: 'System', moderatorLevel: Server.ModeratorLevel.Operator },
       text: '[{"text":"Faites ","color":"LemonChiffon"},{"text":"/help","color":"DarkKhaki"},{"text":" pour plus d\'information","color":"LemonChiffon"}]',
       timestamp: new Date().toISOString(),
       deleted: 0,

--- a/back/src/utils/mappers.ts
+++ b/back/src/utils/mappers.ts
@@ -37,7 +37,7 @@ export function mapUserMessageToMemoryMessage(message: DatabaseMessage): Server.
     id: message.ID?.toString() ?? '',
     user: {
       name: message.Pseudo ?? '',
-      moderatorLevel: message.Moderator ?? 0,
+      moderatorLevel: message.Moderator ?? Server.ModeratorLevel.Player,
     },
     text: message.Texte ?? '',
     timestamp: message.Date ?? '',
@@ -52,7 +52,7 @@ export function mapScoreMessageToMemoryMessage(message: DatabaseMessage): Server
     id: message.ID?.toString() ?? '',
     user: {
       name: message.Pseudo ?? '',
-      moderatorLevel: message.Moderator ?? 0,
+      moderatorLevel: message.Moderator ?? Server.ModeratorLevel.Player,
     },
     answer: message.Answer ?? '',
     attempts: message.Mots ? JSON.parse(message.Mots) : [],

--- a/back/src/ws/connection.ts
+++ b/back/src/ws/connection.ts
@@ -34,7 +34,7 @@ async function buildPrivateUser(sessionHash: string | undefined, usesMobileDevic
 
   return {
     name: getRandomFunnyName(),
-    moderatorLevel: 0,
+    moderatorLevel: Server.ModeratorLevel.Player,
     isLoggedIn: false,
     isMobile: usesMobileDevice,
     words: [],

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx prettier --write . && npm run build --workspace=interfaces && docker compose up --build -d backend & npm run build:front

--- a/front/src/components/Chat/MessagesBox/Message/Message.tsx
+++ b/front/src/components/Chat/MessagesBox/Message/Message.tsx
@@ -47,9 +47,9 @@ function Message({ message }: { message: Server.ChatMessage.Type }): JSX.Element
   const myModeratorLevel = useGameStore((state) => state.player.moderatorLevel);
 
   let id = '';
-  let user: { name: string; moderatorLevel: number } = {
+  let user: { name: string; moderatorLevel: Server.ModeratorLevel } = {
     name: '',
-    moderatorLevel: 0,
+    moderatorLevel: Server.ModeratorLevel.Player,
   };
   if (isTextMessage(message) || isScoreMessage(message)) {
     id = message.content.id;

--- a/front/src/components/Chat/utils.ts
+++ b/front/src/components/Chat/utils.ts
@@ -44,20 +44,19 @@ export const funnyNames = [
   'Chamallow',
 ];
 
-export const rank = {
-  1: 'Admin',
-  2: 'Super-Admin',
-  3: '👑',
+export const tabRank: Partial<Record<Server.ModeratorLevel, string>> = {
+  [Server.ModeratorLevel.Operator]: 'Op',
+  [Server.ModeratorLevel.Owner]: '👑',
 };
 
-export function getPlayerColor(moderatorLevel: number, pseudo: string): string {
+export function getPlayerColor(moderatorLevel: Server.ModeratorLevel, pseudo: string): string {
   if (moderatorLevel) {
     switch (moderatorLevel) {
-      case 1:
+      case Server.ModeratorLevel.Operator:
         return 'rgb(155 185 244)';
-      case 2:
+      case Server.ModeratorLevel.System:
         return 'rgb(150 40 150)';
-      case 3:
+      case Server.ModeratorLevel.Owner:
         return 'rgb(240, 75, 75)';
       default:
         return 'rgb(255, 255, 134)';

--- a/front/src/components/Tab/TabItem/TabItem.tsx
+++ b/front/src/components/Tab/TabItem/TabItem.tsx
@@ -1,6 +1,6 @@
 import { JSX } from 'react';
 import classes from './TabItem.module.css';
-import { getPlayerColor, rank } from '../../Chat/utils';
+import { getPlayerColor, tabRank } from '../../Chat/utils';
 import TabTools from './TabTools/TabTools';
 import phoneIcon from '../../../assets/images/tools/phone.png';
 import computerIcon from '../../../assets/images/tools/computer.png';
@@ -19,9 +19,7 @@ function TabItem({ user }: TabItemProps): JSX.Element {
       <div className={classes.name} style={{ color: getPlayerColor(user.moderatorLevel, user.name) }}>
         {user.name}
       </div>
-      {Object.keys(rank).includes(`${user.moderatorLevel}`) && (
-        <span className={classes.rank}>[{rank[user.moderatorLevel as keyof typeof rank] ?? '?'}]</span>
-      )}
+      {tabRank[user.moderatorLevel] != null && <span className={classes.rank}>[{tabRank[user.moderatorLevel] ?? '?'}]</span>}
       <div className={classes.tools}>
         <TabTools />
       </div>

--- a/interfaces/Message.ts
+++ b/interfaces/Message.ts
@@ -141,10 +141,17 @@ export namespace Server {
 
   export interface User {
     name: string;
-    moderatorLevel: number;
+    moderatorLevel: ModeratorLevel;
     xp: number;
     isMobile: boolean;
     isLoggedIn: boolean;
+  }
+
+  export enum ModeratorLevel {
+    Player = 0,
+    Operator = 1,
+    System = 2,
+    Owner = 3,
   }
 
   export interface PrivateUser extends User {


### PR DESCRIPTION
# Changes
- Added ModeratorLevel enum type
- Removed Super-Admin player rank
  - (the moderatorLevel still exists for System chat messages)
- Renamed Admin to Op
<img width="669" height="546" alt="image" src="https://github.com/user-attachments/assets/1f735411-a69c-490a-8001-5008d55a8040" />

- a deploy.sh script is in there, hmmmmm

# Data migration
```sql
UPDATE surtom.Player
SET IsAdmin = 1
WHERE IsAdmin = 2;
```